### PR TITLE
Backport some Qt calls

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -33,6 +33,8 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent)
         QMessageBox::critical(this, tr("SDL2 Error"), tr("SDL2 failed to initialize. Controller support will be unavailable."));
     }
 
+    qRegisterMetaType<uint16_t>("uint16_t");
+
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
 
@@ -282,7 +284,7 @@ void MainWindow::setConnectedState(bool on)
     if (on) {
         m_connectBtn->setText(tr("Disconnect"));
 
-        QMetaObject::invokeMethod(m_backend, &Backend::connectToConsole, Qt::QueuedConnection, m_wirelessInterfaceComboBox->currentText());
+        QMetaObject::invokeMethod(m_backend, "connectToConsole", Qt::QueuedConnection, Q_ARG(QString, m_wirelessInterfaceComboBox->currentText()));
     } else {
         if (m_backend) {
             m_backend->interrupt();
@@ -314,8 +316,8 @@ void MainWindow::exitFullScreen()
 void MainWindow::volumeChanged(int v)
 {
     qreal vol = v * 0.01;
-    vol = QtAudio::convertVolume(vol, QtAudio::LinearVolumeScale, QtAudio::LogarithmicVolumeScale);
-    QMetaObject::invokeMethod(m_audioHandler, &AudioHandler::setVolume, vol);
+    vol = QAudio::convertVolume(vol, QAudio::LinearVolumeScale, QAudio::LogarithmicVolumeScale);
+    QMetaObject::invokeMethod(m_audioHandler, "setVolume", Q_ARG(qreal, vol));
 }
 
 void MainWindow::showInputConfigDialog()

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -14,6 +14,8 @@
 #include "videodecoder.h"
 #include "viewer.h"
 
+Q_DECLARE_METATYPE(uint16_t)
+
 class MainWindow : public QWidget
 {
     Q_OBJECT

--- a/app/syncprogressdialog.cpp
+++ b/app/syncprogressdialog.cpp
@@ -53,7 +53,7 @@ SyncProgressDialog::SyncProgressDialog(Backend *backend, const QString &wireless
 
     m_backend = backend;
     connect(m_backend, &Backend::syncCompleted, this, &SyncProgressDialog::syncReturned);
-    QMetaObject::invokeMethod(m_backend, &Backend::sync, wirelessInterface, code);
+    QMetaObject::invokeMethod(m_backend, "sync", Q_ARG(QString, wirelessInterface), Q_ARG(uint16_t, code));
 }
 
 void SyncProgressDialog::syncReturned(bool success)


### PR DESCRIPTION
This fixes building with Qt versions below 6.7 without breaking builds on that specific version. Qt 6.7 is a very recent version, and both Debian and Ubuntu (the recently released 24.04 LTS is still on version 6.4!) along with some other distros are still on older versions of Qt.