### PR TITLE
Alpine/musl fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Vanilla currently requires the following dependencies:
   ```
   # pacman -S qt6 ffmpeg libnl sdl2 dhclient
   ```
+- Alpine/postmarketOS
+  ```
+  # apk add qt6-qtbase-dev qt6-qtmultimedia-dev ffmpeg-dev libnl3-dev sdl2-dev dhclient
+  ```
 
 The build process is otherwise normal for a CMake program:
 

--- a/lib/wpa.h
+++ b/lib/wpa.h
@@ -2,6 +2,7 @@
 #define VANILLA_WPA_H
 
 #include <stdlib.h>
+#include <sys/types.h>
 
 struct wpa_ctrl;
 extern const char *wpa_ctrl_interface;


### PR DESCRIPTION
I've been doing some testing with postmarketOS (mobile distro based on Alpine) to try and ascertain the compatibility of smartphone/tablet WiFi chipsets before work starts on an eventual Android port.

Haven't managed to get WiFi picking up yet, but this at least gets vanilla compiling and running.

One small fix - `wpa.h` uses the `pid_t` type, which isn't part of the standard C spec and breaks compilation on musl (and presumably other non-glibc) targets. This is fixed by including the `sys/types.h` header.