### PR TITLE
Use Nix for reproducable building 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+result
 .vscode/
 .directory
 .cache/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,73 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  networkmanager,
+  libnl,
+  openssl,
+  git,
+  SDL2,
+  SDL2_ttf,
+  SDL2_image,
+  libwebp,
+  libtiff,
+  ffmpeg,
+  polkit,
+  libxml2,
+  libx11,
+  libGL,
+  libdrm,
+}:
+let
+  hostap = fetchFromGitHub {
+    owner = "rolandoislas";
+    repo = "drc-hostap";
+    rev = "418e5e206786de2482864a0ec3a59742a33b6623";
+    hash = "sha256-kAv/PetD6Ia5NzmYMWWyWQll1P+N2bL/zaV9ATiGVV0=";
+    leaveDotGit = true;
+  };
+in
+stdenv.mkDerivation {
+  pname = "vanilla-wiiu";
+  version = "continuous";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    git
+  ];
+  buildInputs = [
+    networkmanager
+    libnl
+    openssl
+    SDL2
+    SDL2_ttf
+    SDL2_image
+    libwebp
+    libtiff
+    ffmpeg
+    polkit
+    libxml2
+    libx11
+    libGL
+    libdrm
+  ];
+
+  postPatch = ''
+    substituteInPlace pipe/linux/CMakeLists.txt \
+      --replace-fail "https://github.com/rolandoislas/drc-hostap.git" "${hostap}" \
+      --replace-fail "--branch master" "--branch fetchgit"
+  '';
+
+  meta = {
+    description = "A software clone of the Wii U gamepad for Linux";
+    homepage = "https://github.com/vanilla-wiiu/vanilla";
+    license = lib.licenses.gpl2;
+    mainProgram = "vanilla";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785599192,
+        "narHash": "sha256-dg4RTtDxnXY13UkJNdhmgTUTl0n/IJBlCigfO7nutZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6d65bfc1bcef2ef39a239d38e577e92a89fb0f07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,9 @@
+{
+  description = "A software clone of the Wii U gamepad";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+  outputs = { self, nixpkgs }: {
+    packages = nixpkgs.lib.genAttrs nixpkgs.lib.platforms.linux (system: {
+      default = (import nixpkgs { inherit system; }).callPackage ./default.nix { };
+    });
+  };
+}

--- a/gui/ui/ui_sdl.c
+++ b/gui/ui/ui_sdl.c
@@ -6,9 +6,9 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_hints.h>
 #include <SDL2/SDL_syswm.h>
-#include <SDL_image.h>
-#include <SDL_power.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_power.h>
+#include <SDL2/SDL_ttf.h>
 #include <pthread.h>
 #include <time.h>
 #include <vanilla.h>


### PR DESCRIPTION
This PR adds files for building vanilla with the Nix build system.

Nix is
- A build system
- A package manager
- A package repository ([nixpkgs](https://github.com/nixos/nixpkgs))
- An operating system ([NixOS](https://nixos.org))

This PR adds a Nix Flake, which defines a set of dependencies and instructions on how to build Vanilla.

A flake in the Vanilla repository would allow Nix users to run vanilla with one command: `nix run github:vanilla-wiiu/vanilla`.

Nix could potentially replace Linux builds in the CI workflow to guarantee that CI-produced binaries are identical to locally-produced binaries, which could be useful for future issue diagnosis.

Finally, Nix build support would make it significantly easier for people running NixOS to run vanilla, as NixOS does not support generic dynamically-linked executables because it does not implement a typical [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard).

Please read through [nix.dev](https://nix.dev/) for more on Nix and why it is useful if you have the time :)

### **To test:**

To test this, install Nix from [https://nixos.org/download/](https://nixos.org/download/) and run `nix run github:headblockhead/vanilla` which will build and run vanilla using Nix.

### Alternatives:

Additionally, I am currently adding vanilla to [nixpkgs](https://github.com/nixos/nixpkgs), which is NixOS's equivalent to Arch's AUR, and will make a PR to note this in the README when I am done. However, this would make it my responsibility to maintain instead.