### PR TITLE
fix: add missing braces to switch case

### DIFF
--- a/lib/gamepad/command.c
+++ b/lib/gamepad/command.c
@@ -298,6 +298,7 @@ void handle_generic_packet(int skt, GenericPacket *request)
     case SERVICE_ID_SYSTEM:
         switch (gen_cmd->method_id) {
         case METHOD_ID_SYSTEM_GET_INFO:
+        {
             SystemInfo *info = (SystemInfo *)&response.payload[0];
             info->board_ver = htonl(BOARD_VERSION_MASS);
             info->chip_ver = htonl(CHIP_VERSION_ES3);
@@ -309,6 +310,7 @@ void handle_generic_packet(int skt, GenericPacket *request)
             response.generic_cmd_header.payload_size = htons(sizeof(SystemInfo));
             response.generic_cmd_header.error_code = 0;
             break;
+        }
         }
         break;
     case SERVICE_ID_PERIPHERAL:


### PR DESCRIPTION
This resolves a build error on macOS/clang 17. Due to declaring a variable immediately after a case label in the switch, we need to wrap the case in braces.