### PR TITLE
lib: use pthread_setname_np directly

### DIFF
--- a/lib/gamepad/gamepad.c
+++ b/lib/gamepad/gamepad.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include "gamepad.h"
 
 #include <arpa/inet.h>
@@ -232,16 +234,16 @@ int connect_as_gamepad_internal(event_loop_t *event_loop, uint32_t server_addres
     pthread_t video_thread, audio_thread, input_thread, msg_thread, cmd_thread;
 
     pthread_create(&video_thread, NULL, listen_video, &info);
-    name_thread(video_thread, "vanilla-video");
+    pthread_setname_np(video_thread, "vanilla-video");
 
     pthread_create(&audio_thread, NULL, listen_audio, &info);
-    name_thread(audio_thread, "vanilla-audio");
+    pthread_setname_np(audio_thread, "vanilla-audio");
 
     pthread_create(&input_thread, NULL, listen_input, &info);
-    name_thread(input_thread, "vanilla-input");
+    pthread_setname_np(input_thread, "vanilla-input");
     
     pthread_create(&cmd_thread, NULL, listen_command, &info);
-    name_thread(cmd_thread, "vanilla-cmd");
+    pthread_setname_np(cmd_thread, "vanilla-cmd");
 
     while (1) {
         usleep(250 * 1000);

--- a/lib/util.c
+++ b/lib/util.c
@@ -1,6 +1,5 @@
 #include "util.h"
 
-#include <dlfcn.h>
 #include <math.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -64,21 +63,6 @@ uint16_t crc16(const void *data, size_t len)
     }
 
     return crc;
-}
-
-static int (*ppthread_setname_np)(pthread_t, const char*) = NULL;
-static int checked_for_pthread_setname_np = 0;
-void name_thread(pthread_t thread, const char *name)
-{
-    if (!checked_for_pthread_setname_np) {
-        void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
-        ppthread_setname_np = (int(*)(pthread_t, const char*)) fn;
-        checked_for_pthread_setname_np = 1;
-    }
-
-    if (ppthread_setname_np) {
-        ppthread_setname_np(thread, name);
-    }
 }
 
 size_t get_millis()

--- a/lib/util.h
+++ b/lib/util.h
@@ -19,7 +19,6 @@ int is_interrupted();
 void force_interrupt();
 void install_interrupt_handler();
 void uninstall_interrupt_handler();
-void name_thread(pthread_t thread, const char *name);
 size_t get_millis();
 
 uint16_t crc16(const void* data, size_t len);

--- a/lib/vanilla.c
+++ b/lib/vanilla.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include "vanilla.h"
 
 #include <pthread.h>
@@ -60,7 +62,7 @@ int vanilla_start_internal(uint32_t server_address)
 
         // Start other thread (which will set event loop to active)
         pthread_create(&other, NULL, start_gamepad, data);
-        name_thread(other, "vanilla-gamepad");
+        pthread_setname_np(other, "vanilla-gamepad");
 
         // Wait for event loop to be set active before returning
         while (!event_loop.active) {


### PR DESCRIPTION
since pthread_setname_np is non-portable (hence the _np), it is only declared if you #define _GNU_SOURCE