### PR TITLE
add dockerless CI workflow to build *and* test Vanilla

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Build and run tests
+on:
+  push:
+    paths-ignore:
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'README.md'
+jobs:
+  linux:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: sudo apt-get -yU install libavfilter-dev libnl-genl-3-dev libsdl2-dev ninja-build qt6-multimedia-dev qt6-svg-dev
+
+    - name: Build Vanilla
+      run: |
+        WERROR_FLAGS="" # need PR #110 to be merged first to enable -Wall -Werror
+        SANITIZE_FLAGS="-fsanitize=address,undefined"
+        CC_FLAGS="$WERROR_FLAGS $SANITIZE_FLAGS"
+        cmake -B ${{github.workspace}}/builddir -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="$CC_FLAGS" -DCMAKE_C_FLAGS="$CC_FLAGS" -DCMAKE_EXE_LINKER_FLAGS="$SANITIZE_FLAGS" -DCMAKE_SHARED_LINKER_FLAGS="$SANITIZE_FLAGS" -DVANILLA_BUILD_TESTS=ON -DVANILLA_BUILD_RPI=ON
+        cmake --build builddir -j
+
+    - name: Run unit tests
+      working-directory: ${{github.workspace}}/builddir/lib
+      run: ctest

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,16 +22,18 @@ endif()
 install(TARGETS vanilla)
 
 if (VANILLA_BUILD_TESTS)
-    function(add_test TEST_NAME TEST_FILES)
+    include(CTest)
+    function(vanilla_add_test TEST_NAME TEST_FILES)
         add_executable(${TEST_NAME}
             ${TEST_FILES}
         )
 
         target_link_libraries(${TEST_NAME} PRIVATE vanilla m)
         target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+        add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     endfunction()
-    
-    add_test(bittest "test/bittest.c")
-    add_test(reversebittest "test/reversebit.c")
-    add_test(reversebitstresstest "test/reversebitstresstest.c")
+
+    vanilla_add_test(bittest "test/bittest.c")
+    vanilla_add_test(reversebittest "test/reversebit.c")
+    vanilla_add_test(reversebitstresstest "test/reversebitstresstest.c")
 endif()


### PR DESCRIPTION
This workflow builds Vanilla with ASan and UBsan, and runs the unit tests in lib/.

In addition, this commit adds CTest integration so that all the tests can be run by executing `ctest` in builddir/lib

I hope this can provide a more reliable indicator of code quality over the existing Docker based CI, which of course isn't working right now.

Preferably, #110 should be merged first, so I can add `-Wall -Werror` in this PR.