### PR TITLE
Changed qt6-svg-dev to libqt6svg6-dev for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Vanilla currently requires the following dependencies:
 
 - Debian/Ubuntu 
   ```
-  # apt install qt6-base-dev qt6-multimedia-dev qt6-svg-dev libavcodec-dev libavutil-dev libavfilter-dev libsdl2-dev libnl-genl-3-dev isc-dhcp-client libssl-dev build-essential cmake
+  # apt install qt6-base-dev qt6-multimedia-dev libqt6svg6-dev libavcodec-dev libavutil-dev libavfilter-dev libsdl2-dev libnl-genl-3-dev isc-dhcp-client libssl-dev build-essential cmake
   ```
 - Fedora
   ```


### PR DESCRIPTION
This changes said package name to the proper one that exists for apt users. This is so that apt users won't enter input package that doesn't exist when installing the dependencies required for compiling. I tested this package and I was still able to properly compile the program. 