### PR TITLE
CLI argument improvement

### DIFF
--- a/gui/main.c
+++ b/gui/main.c
@@ -18,15 +18,28 @@
 #include "game/game_main.h"
 #include "pipemgmt.h"
 
+void display_cli_help();
+
 int SDL_main(int argc, const char **argv)
 {
     // Default to full screen unless "-w" is specified
     int fs = 1;
-    for (int i = 1; i < argc; i++) {
-        if (!strcmp(argv[i], "-w")) {
-            fs = 0;
-        }
-    }
+	for (int i = 1, consumed; i < argc; i += consumed) {
+		consumed = -1;
+		 if (!strcmp(argv[i], "-w") || !strcmp(argv[i], "--window")) {
+			fs = 0;
+			consumed = 1;
+		}
+		else if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {
+			display_cli_help();
+			return 0;
+		}
+		if (consumed <= 0) {
+			vpilog("Invalid argument(s): %s\n\n", argv[i]);
+			display_cli_help();
+			return 1;
+		}
+	}
 
     vanilla_install_logger(vpilog_va);
 
@@ -60,4 +73,11 @@ exit:
     vpi_config_free();
 
     return ret;
+}
+
+void display_cli_help() {
+	vpilog("Usage: vanilla-pi [options]\n\n");
+	vpilog("Options:\n");
+	vpilog("	-w, --window	Run Vanilla-Pi in a window\n");
+	vpilog("	-h, --help	Show this help message\n");
 }

--- a/gui/main.c
+++ b/gui/main.c
@@ -76,8 +76,8 @@ exit:
 }
 
 void display_cli_help() {
-	vpilog("Usage: vanilla-pi [options]\n\n");
+	vpilog("Usage: vanilla [options]\n\n");
 	vpilog("Options:\n");
-	vpilog("	-w, --window	Run Vanilla-Pi in a window\n");
+	vpilog("	-w, --window	Run Vanilla in a window\n");
 	vpilog("	-h, --help	Show this help message\n");
 }


### PR DESCRIPTION
- Add --help/-h CLI argument
- Add functionality for further CLI argument implementation

```
~/vanilla/build$ ./bin/vanilla-pi --help
Usage: vanilla-pi [options]

Options:
        -w, --window    Run Vanilla-Pi in a window
        -h, --help      Show this help message
```