### PR TITLE
 Add AUR package section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This is a **work-in-progress** software clone of the Wii U gamepad for Linux (in
 
 ## What devices are supported?
 
-- [Steam Deck](https://github.com/vanilla-wiiu/vanilla/wiki/Steam-Deck)
-- [Linux](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (check [Wi-Fi hardware compatibility](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility))
-- [Nintendo Switch](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (requires [Broadcom firmware patch](https://github.com/vanilla-wiiu/nexmon) or [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#nintendo-switch))
-- [Android](https://github.com/vanilla-wiiu/vanilla/wiki/Android-Setup-Guide) (currently frontend only)
-- [Windows](https://github.com/vanilla-wiiu/vanilla/wiki/Windows-Setup-Guide) (currently frontend only)
-- [Raspberry Pi](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (requires [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#raspberry-pi))
-- *iOS* - Coming soon
+* [Steam Deck](https://github.com/vanilla-wiiu/vanilla/wiki/Steam-Deck)
+* [Linux](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (check [Wi-Fi hardware compatibility](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility))
+* [Nintendo Switch](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (requires [Broadcom firmware patch](https://github.com/vanilla-wiiu/nexmon) or [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#nintendo-switch))
+* [Android](https://github.com/vanilla-wiiu/vanilla/wiki/Android-Setup-Guide) (currently frontend only)
+* [Windows](https://github.com/vanilla-wiiu/vanilla/wiki/Windows-Setup-Guide) (currently frontend only)
+* [Raspberry Pi](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (requires [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#raspberry-pi))
+* *iOS* - Coming soon
 
 ## What Wi-Fi adapter should I use?
 
@@ -27,21 +27,26 @@ At a minimum, you will need an adapter that supports 802.11n 5GHz. Newer standar
 In practice, not all hardware/drivers appear to work at this time. Check the [Wireless Compatibility](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility) page on the wiki to check if a card is confirmed working or not.
 
 ## Compiling (Linux)
+
 Vanilla currently requires the following dependencies:
 
-- Debian/Ubuntu 
+* **Debian/Ubuntu**:
+
   ```sh
   apt install build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libnl-genl-3-dev libnl-route-3-dev libssl-dev libxml2-dev libnm-dev
   ```
-- Fedora
+* **Fedora**:
+
   ```sh
   dnf install libavcodec-free-devel libavutil-free-devel libavfilter-free-devel libnl3-devel SDL2-devel SDL2_image-devel SDL2_ttf-devel openssl-devel make automake gcc gcc-c++ kernel-devel cmake libxml2-devel NetworkManager-libnm-devel
   ```
-- Arch
+* **Arch**:
+
   ```sh
   pacman -S base-devel make cmake ffmpeg libnl sdl2 sdl2_image sdl2_ttf libxml2 libnm
   ```
-- Alpine/postmarketOS
+* **Alpine/postmarketOS**:
+
   ```sh
   apk add build-base cmake sdl2-dev sdl2_image-dev sdl2_ttf-dev ffmpeg-dev libnl3-dev libxml2-dev openssl-dev networkmanager-dev
   ```
@@ -61,3 +66,13 @@ Optionally, to install the program:
 ```
 sudo cmake --install .
 ```
+
+## AUR Package
+
+An Arch User Repository (AUR) package is available for easy installation on Arch Linux and derivatives:
+
+```sh
+yay -S vanilla-wiiu-git
+```
+
+For more information, see the AUR page: [https://aur.archlinux.org/packages/vanilla-wiiu-git](https://aur.archlinux.org/packages/vanilla-wiiu-git)


### PR DESCRIPTION
This PR adds a new **AUR Package** section to the project’s README, making it easier for Arch users to install via the Arch User Repository. It includes:

* A new `## AUR Package` heading
* The installation command (`yay -S vanilla-wiiu-git`)
* A link to the AUR package page on the Arch User Repository
