### PR TITLE
gui: segmentation fault when controller name is NULL

### DIFF
--- a/gui/ui/ui_sdl.c
+++ b/gui/ui/ui_sdl.c
@@ -166,7 +166,7 @@ void find_valid_controller(vui_sdl_context_t *sdl_ctx)
 	for (int i = 0; i < SDL_NumJoysticks(); i++) {
         const char *ctrl_name = SDL_GameControllerNameForIndex(i);
 		vpilog("  Found %i: %s\n", i, ctrl_name);
-        if (!strcmp(ctrl_name, "Steam Virtual Gamepad")) {
+        if (ctrl_name != NULL && !strcmp(ctrl_name, "Steam Virtual Gamepad")) {
             steam_virtual_gamepad_index = i;
         } else if (controller == -1) {
             controller = i;


### PR DESCRIPTION
the `strcmp()` added in commit 72380441c5ecf1f4c67f9abe2f841a67d3f57430 causes vanilla to segfault:
```
Looking for game controllers...
  Found 0: Steam Controller
  Found 1: PS3 Controller
  Found 2: (null)
[1]    191061 segmentation fault (core dumped)  ./build/bin/vanilla
```
<details>
<summary>gdb output</summary>

```
Thread 1 "vanilla" received signal SIGSEGV, Segmentation fault.
__strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:283
283             VMOVU   (%rdi), %ymm0
(gdb) bt
#0  __strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:283
#1  0x0000555555567811 in find_valid_controller (sdl_ctx=0x5555559565e0)
    at /home/sheepy/Desktop/gamepad/vanilla/gui/ui/ui_sdl.c:169
#2  0x00005555555694ac in vui_init_sdl (ctx=0x5555557f0e80, fullscreen=0)
    at /home/sheepy/Desktop/gamepad/vanilla/gui/ui/ui_sdl.c:744
#3  0x000055555555c047 in main (argc=1, argv=0x7fffffffd4a8) at /home/sheepy/Desktop/gamepad/vanilla/gui/main.c:65
```

</details>

because the index range for `SDL_GameControllerNameForIndex()` is [0, `SDL_NumJoysticks() - 1`] ([SDL docs](https://wiki.libsdl.org/SDL2/SDL_GameControllerNameForIndex)), so the for loop's condition is off-by-one.

also added a nullptr check for good measure, since apparently the name can also be returned as null?

new output:
```
Looking for game controllers...
  Found 0: Steam Controller
  Found 1: PS3 Controller
Using game controller "Steam Controller"
```