### PR TITLE
Fix lockup when Polkit prompt cancelled

### DIFF
--- a/gui/pipemgmt.c
+++ b/gui/pipemgmt.c
@@ -317,6 +317,8 @@ int vpi_start_epilog()
             // vpilog("GOT INVALID SIGNAL: %.*s\n", sizeof(ready_buf), ready_buf);
             vpilog("%.*s\n", sizeof(ready_buf), ready_buf);
 
+            break;
+
             // Kill seems to break a lot of things so I guess we'll just leave it orphaned
             // kill(pipe_pid, SIGKILL);
 


### PR DESCRIPTION
Has Vanilla return an error if Polkit prompt is cancelled, instead of simply locking up.

Fixes #341 


https://github.com/user-attachments/assets/aee41467-ba9d-4e73-8248-2201a6187eeb

