### PR TITLE
feat: Add Cursor Visibility Flags

### DIFF
--- a/gui/main.c
+++ b/gui/main.c
@@ -103,5 +103,7 @@ void display_cli_help(const char **argv) {
 	vpilog("Options:\n");
 	vpilog("    -w, --window        Run Vanilla in a window (overrides config)\n");
 	vpilog("    -f, --fullscreen    Run Vanilla full screen (overrides config)\n");
+    vpilog("    --show-cursor       Run Vanilla with the cursor visible (overrides config)\n");
+    vpilog("    --no-cursor         Run Vanilla without the cursor visible (overrides config)\n");
 	vpilog("    -h, --help          Show this help message\n");
 }

--- a/gui/main.c
+++ b/gui/main.c
@@ -23,6 +23,7 @@ int SDL_main(int argc, const char **argv)
 {
     // Default to full screen unless "-w" is specified
     int override_fs = -1;
+    int override_fs_cursor = -1;
 	for (int i = 1, consumed; i < argc; i += consumed) {
 		consumed = -1;
 		 if (!strcmp(argv[i], "-w") || !strcmp(argv[i], "--window")) {
@@ -30,6 +31,12 @@ int SDL_main(int argc, const char **argv)
 			consumed = 1;
 		} else if (!strcmp(argv[i], "-f") || !strcmp(argv[i], "--fullscreen")) {
             override_fs = 1;
+            consumed = 1;
+        } else if (!strcmp(argv[i], "--show-cursor")) {
+            override_fs_cursor = 1;
+            consumed = 1;
+        } else if (!strcmp(argv[i], "--no-cursor")) {
+            override_fs_cursor = 0;
             consumed = 1;
 		} else if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {
 			display_cli_help(argv);
@@ -55,6 +62,10 @@ int SDL_main(int argc, const char **argv)
     // Check if override fullscreen, if so set it in the config, but don't save
     if (override_fs != -1) {
         vpi_config.fullscreen = override_fs;
+    }
+
+    if(override_fs_cursor != -1) {
+        vpi_config.cursor_in_fullscreen = override_fs_cursor;
     }
 
     // Initialize UI system


### PR DESCRIPTION
Added 2 flags to enable/disable showing the cursor, as currently I (personally) don't see a way the user is suppose to do this. 

I chose to just use long-named flags as I don't want to use up potentionally useful short flags (-c, -n) that may be used in the future.

Note:
I was going to add a GUI checkable button for this but couldn't find a good place for it in the menus.