### PR TITLE
Call "rfkill unblock wlan" as part of wpa_supplicant initialization

### DIFF
--- a/pipe/linux/wpa.c
+++ b/pipe/linux/wpa.c
@@ -312,6 +312,8 @@ void *wpa_setup_environment(void *data)
     interface.ifname = args->wireless_interface;
     interface.confname = args->wireless_config;
 
+    run_process_and_read_stdout((const char *[]) {"rfkill", "unblock", "wlan", NULL}, 0, 0);
+
     struct wpa_global *wpa = wpa_supplicant_init(&params);
     if (!wpa) {
         nlprint("FAILED TO INIT WPA SUPPLICANT");


### PR DESCRIPTION
While I personally never encountered this, drc-sim makes this call, and [at least one person](https://github.com/vanilla-wiiu/vanilla/discussions/44#discussioncomment-15808186) has had this issue so we may as well call it.