### PR TITLE
fix: windowed config/flag was ignored at startup, even VANILLA_GUI_ENABLE_WINDOWED is enabled

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -400,7 +400,7 @@ endif()
 
 OPTION(VANILLA_GUI_ENABLE_WINDOWED "Enable windowed mode in Vanilla GUI" ON)
 if (VANILLA_GUI_ENABLE_WINDOWED)
-    target_compile_definitions(vanillagui PRIVATE VANILLA_GUI_ENABLE_WINDOWED)
+    target_compile_definitions(vanillagui PUBLIC VANILLA_GUI_ENABLE_WINDOWED)
 endif()
 
 if (VANILLA_BUILD_USE_POLKIT)


### PR DESCRIPTION
main.c forces fullscreen if VANILLA_GUI_ENABLE_WINDOWED is not defined at build time, but d9f16d48025f59ce40772594d653b727c49c4bd6 moves almost everything other than main.c to `vanillagui` target, so main.c now wouldn't get VANILLA_GUI_ENABLE_WINDOWED anymore.