### PR TITLE
input: fix gyro axis being mapped incorrectly

### DIFF
--- a/lib/gamepad/input.c
+++ b/lib/gamepad/input.c
@@ -127,8 +127,8 @@ static inline int32_t s24_le_to_int32(const uint8_t in[3])
 static inline void pack_gyroscope(InputPacketGyroscope *gyro, int32_t yaw, int32_t pitch, int32_t roll)
 {
     int32_to_s24_le(gyro->yaw, yaw);
-    int32_to_s24_le(gyro->pitch, yaw);
-    int32_to_s24_le(gyro->roll, yaw);
+    int32_to_s24_le(gyro->pitch, pitch);
+    int32_to_s24_le(gyro->roll, roll);
 }
 
 static inline uint16_t pack_touchcoord(TouchCoord *unpacked)


### PR DESCRIPTION
the pack gyroscope function was mapping yaw to every axis, instead of every respective axis,
splatoon is now playable again :D

this closes #375 and #362
