### PR TITLE
gui: changed card icons to better match wiiU console

### DIFF
--- a/gui/assets/tex/club.svg
+++ b/gui/assets/tex/club.svg
@@ -1,11 +1,62 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#0A0B0B" d="M19.21,28.22c-12.744,0-12.976,16.22,0,16.22c7.647,0,11.818-7.491,14.367-4.865
-	c2.395,2.472-1.391,15.911-1.699,18.073c-0.464,2.936,2.008,5.253,4.712,5.253c2.857,0,4.865-2.317,4.325-5.253
-	c-0.387-2.162-3.785-15.524-1.313-18.073c2.395-2.472,7.029,4.942,15.217,4.865c11.662-0.076,11.662-16.22,0-16.22
-	c-8.033,0-12.745,7.415-15.217,4.943c-2.317-2.317,4.943-5.021,4.943-12.899c0-11.432-16.065-11.432-16.065-0.077
-	c0,7.956,7.492,10.736,5.098,12.976C30.951,35.635,26.857,28.22,19.21,28.22z"/>
-</svg>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="club.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.9,12.336927"
+     end_point="36.9,65.315523"
+     center_point="36.9,38.826225"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showguides="true"
+   inkscape:zoom="16.000001"
+   inkscape:cx="55.343748"
+   inkscape:cy="38.374998"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+
+<path
+   fill="#0a0b0b"
+   d="m 36.892578,12.328125 c -11.990796,0 -15.483902,13.418217 -9.914062,19.753906 -9.788878,-2.403362 -18.0898357,6.949047 -13.958985,16.69336 3.407902,8.03894 15.657261,9.022179 21.578125,2.974609 0,0 0.262441,8.9431 -4.457031,10.724609 H 43.660156 C 38.940684,60.6931 39.203125,51.75 39.203125,51.75 c 5.920864,6.04757 18.170223,5.064331 21.578125,-2.974609 4.130851,-9.744313 -4.172059,-19.096722 -13.960938,-16.69336 5.56984,-6.335689 2.076734,-19.753906 -9.914062,-19.753906 -0.0022,0 -0.0036,-6e-6 -0.0059,0 -0.0022,-6e-6 -0.0056,0 -0.0078,0 z"
+   id="path1"
+   sodipodi:nodetypes="sccssscscscs"
+   transform="matrix(-1.001326,0,0,1,72.949235,-0.07812252)"
+   inkscape:label="path1"
+   style="display:inline" /></svg>

--- a/gui/assets/tex/club_black.svg
+++ b/gui/assets/tex/club_black.svg
@@ -1,11 +1,62 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#404040" d="M19.21,28.22c-12.744,0-12.976,16.22,0,16.22c7.647,0,11.818-7.491,14.367-4.865
-	c2.395,2.472-1.391,15.911-1.699,18.073c-0.464,2.936,2.008,5.253,4.712,5.253c2.857,0,4.865-2.317,4.325-5.253
-	c-0.387-2.162-3.785-15.524-1.313-18.073c2.395-2.472,7.029,4.942,15.217,4.865c11.662-0.076,11.662-16.22,0-16.22
-	c-8.033,0-12.745,7.415-15.217,4.943c-2.317-2.317,4.943-5.021,4.943-12.899c0-11.432-16.065-11.432-16.065-0.077
-	c0,7.956,7.492,10.736,5.098,12.976C30.951,35.635,26.857,28.22,19.21,28.22z"/>
-</svg>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="club_black.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.9,12.336927"
+     end_point="36.9,65.315523"
+     center_point="36.9,38.826225"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showguides="true"
+   inkscape:zoom="8"
+   inkscape:cx="49.75"
+   inkscape:cy="7.375"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+
+<path
+   fill="#0a0b0b"
+   d="m 36.892578,12.328125 c -11.990796,0 -15.483902,13.418217 -9.914062,19.753906 -9.788878,-2.403362 -18.0898357,6.949047 -13.958985,16.69336 3.407902,8.03894 15.657261,9.022179 21.578125,2.974609 0,0 0.262441,8.9431 -4.457031,10.724609 H 43.660156 C 38.940684,60.6931 39.203125,51.75 39.203125,51.75 c 5.920864,6.04757 18.170223,5.064331 21.578125,-2.974609 4.130851,-9.744313 -4.172059,-19.096722 -13.960938,-16.69336 5.56984,-6.335689 2.076734,-19.753906 -9.914062,-19.753906 -0.0022,0 -0.0036,-6e-6 -0.0059,0 -0.0022,-6e-6 -0.0056,0 -0.0078,0 z"
+   id="path1"
+   sodipodi:nodetypes="sccssscscscs"
+   transform="matrix(-1.001326,0,0,1,72.949235,-0.07812252)"
+   inkscape:label="path1"
+   style="display:inline;fill:#404040;fill-opacity:1" /></svg>

--- a/gui/assets/tex/club_white.svg
+++ b/gui/assets/tex/club_white.svg
@@ -1,11 +1,62 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#FFFFFF" d="M19.21,28.22c-12.744,0-12.976,16.22,0,16.22c7.647,0,11.818-7.491,14.367-4.865
-	c2.395,2.472-1.391,15.911-1.699,18.073c-0.464,2.936,2.008,5.253,4.712,5.253c2.857,0,4.865-2.317,4.325-5.253
-	c-0.387-2.162-3.785-15.524-1.313-18.073c2.395-2.472,7.029,4.942,15.217,4.865c11.662-0.076,11.662-16.22,0-16.22
-	c-8.033,0-12.745,7.415-15.217,4.943c-2.317-2.317,4.943-5.021,4.943-12.899c0-11.432-16.065-11.432-16.065-0.077
-	c0,7.956,7.492,10.736,5.098,12.976C30.951,35.635,26.857,28.22,19.21,28.22z"/>
-</svg>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="club_white.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.9,12.336927"
+     end_point="36.9,65.315523"
+     center_point="36.9,38.826225"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showguides="true"
+   inkscape:zoom="11.313709"
+   inkscape:cx="63.197666"
+   inkscape:cy="33.499182"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+
+<path
+   fill="#0a0b0b"
+   d="m 36.892578,12.328125 c -11.990796,0 -15.483902,13.418217 -9.914062,19.753906 -9.788878,-2.403362 -18.0898357,6.949047 -13.958985,16.69336 3.407902,8.03894 15.657261,9.022179 21.578125,2.974609 0,0 0.262441,8.9431 -4.457031,10.724609 H 43.660156 C 38.940684,60.6931 39.203125,51.75 39.203125,51.75 c 5.920864,6.04757 18.170223,5.064331 21.578125,-2.974609 4.130851,-9.744313 -4.172059,-19.096722 -13.960938,-16.69336 5.56984,-6.335689 2.076734,-19.753906 -9.914062,-19.753906 -0.0022,0 -0.0036,-6e-6 -0.0059,0 -0.0022,-6e-6 -0.0056,0 -0.0078,0 z"
+   id="path1"
+   sodipodi:nodetypes="sccssscscscs"
+   transform="matrix(-1.001326,0,0,1,72.949235,-0.07812252)"
+   inkscape:label="path1"
+   style="display:inline;fill:#ffffff;fill-opacity:1" /></svg>

--- a/gui/assets/tex/diamond.svg
+++ b/gui/assets/tex/diamond.svg
@@ -1,8 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#ED2224" d="M36.143,9.601c-5.631,9.257-16.662,20.982-25.688,27.154c9.026,5.708,20.057,17.896,25.688,26.846
-	c5.632-8.949,17.28-21.138,25.998-27.077C53.423,30.583,41.774,18.857,36.143,9.601z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="diamond.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.15,9.601"
+     end_point="36.15,63.601"
+     center_point="36.15,36.601"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="5.6568542"
+   inkscape:cx="82.731493"
+   inkscape:cy="21.213203"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#ed2224"
+   d="m 36.142578,9.6015625 c -1.556807,3.9038415 -17.24694,23.8159095 -22.09375,27.5136715 11.352885,8.37303 20.593716,23.431382 22.09375,26.486328 l 0.0078,-0.01172 0.0059,0.01172 C 37.656284,60.546616 46.899068,45.488264 58.251953,37.115234 53.405143,33.417472 37.713057,13.505403 36.15625,9.6015625 l -0.0059,0.011719 z"
+   id="path1"
+   style="display:inline;opacity:1"
+   sodipodi:nodetypes="ccccc" />
 </svg>

--- a/gui/assets/tex/diamond_black.svg
+++ b/gui/assets/tex/diamond_black.svg
@@ -1,8 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#404040" d="M36.143,9.601c-5.631,9.257-16.662,20.982-25.688,27.154c9.026,5.708,20.057,17.896,25.688,26.846
-	c5.632-8.949,17.28-21.138,25.998-27.077C53.423,30.583,41.774,18.857,36.143,9.601z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="diamond_black.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.15,9.601"
+     end_point="36.15,63.601"
+     center_point="36.15,36.601"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="4"
+   inkscape:cx="78"
+   inkscape:cy="52.5"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#ed2224"
+   d="m 36.142578,9.6015625 c -1.556807,3.9038415 -17.24694,23.8159095 -22.09375,27.5136715 11.352885,8.37303 20.593716,23.431382 22.09375,26.486328 l 0.0078,-0.01172 0.0059,0.01172 C 37.656284,60.546616 46.899068,45.488264 58.251953,37.115234 53.405143,33.417472 37.713057,13.505403 36.15625,9.6015625 l -0.0059,0.011719 z"
+   id="path1"
+   style="display:inline;opacity:1;fill:#404040;fill-opacity:1"
+   sodipodi:nodetypes="ccccc" />
 </svg>

--- a/gui/assets/tex/diamond_white.svg
+++ b/gui/assets/tex/diamond_white.svg
@@ -1,8 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#FFFFFF" d="M36.143,9.601c-5.631,9.257-16.662,20.982-25.688,27.154c9.026,5.708,20.057,17.896,25.688,26.846
-	c5.632-8.949,17.28-21.138,25.998-27.077C53.423,30.583,41.774,18.857,36.143,9.601z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="diamond_white.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.15,9.601"
+     end_point="36.15,63.601"
+     center_point="36.15,36.601"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="4"
+   inkscape:cx="78"
+   inkscape:cy="52.5"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#ed2224"
+   d="m 36.142578,9.6015625 c -1.556807,3.9038415 -17.24694,23.8159095 -22.09375,27.5136715 11.352885,8.37303 20.593716,23.431382 22.09375,26.486328 l 0.0078,-0.01172 0.0059,0.01172 C 37.656284,60.546616 46.899068,45.488264 58.251953,37.115234 53.405143,33.417472 37.713057,13.505403 36.15625,9.6015625 l -0.0059,0.011719 z"
+   id="path1"
+   style="display:inline;opacity:1;fill:#ffffff"
+   sodipodi:nodetypes="ccccc" />
 </svg>

--- a/gui/assets/tex/heart.svg
+++ b/gui/assets/tex/heart.svg
@@ -1,9 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#ED2224" d="M35.84,21.358c-11.368-11.92-27-6-27,9c0,14.684,14.842,18.631,21.158,24.947
-	c0.947,0.947,3.711,3.474,5.921,7.895c2.289-4.421,4.974-6.947,5.921-7.895c6-6.316,21-10.264,21-24.632
-	C62.84,15.358,47.051,9.438,35.84,21.358z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="heart.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="35.919,15.006906"
+     end_point="35.919,64.825"
+     center_point="35.919,39.915953"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="1.4142136"
+   inkscape:cx="-66.114484"
+   inkscape:cy="154.14928"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#ed2224"
+   d="m 23.435547,17.015625 c -6.392303,0.07523 -12.095703,5.616342 -12.095703,13.404297 0,7.571079 4.240915,12.408022 11.095703,18.134765 3.22825,2.697001 8.618125,7.379782 13.484375,11.894532 4.86625,-4.51475 10.254172,-9.197531 13.482422,-11.894532 6.854788,-5.726744 11.095703,-10.563686 11.095703,-18.134765 0,-13.116556 -16.174681,-19.860331 -24.578125,-4.84961 -3.413899,-6.098105 -8.110694,-8.60616 -12.484375,-8.554687 z"
+   id="path1"
+   style="opacity:1"
+   sodipodi:nodetypes="csscc" />
 </svg>

--- a/gui/assets/tex/heart_black.svg
+++ b/gui/assets/tex/heart_black.svg
@@ -1,9 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#404040" d="M35.84,21.358c-11.368-11.92-27-6-27,9c0,14.684,14.842,18.631,21.158,24.947
-	c0.947,0.947,3.711,3.474,5.921,7.895c2.289-4.421,4.974-6.947,5.921-7.895c6-6.316,21-10.264,21-24.632
-	C62.84,15.358,47.051,9.438,35.84,21.358z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="heart_black.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="35.919,15.006906"
+     end_point="35.919,64.825"
+     center_point="35.919,39.915953"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="1.4142136"
+   inkscape:cx="-66.468036"
+   inkscape:cy="154.85638"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#ed2224"
+   d="m 23.435547,17.015625 c -6.392303,0.07523 -12.095703,5.616342 -12.095703,13.404297 0,7.571079 4.240915,12.408022 11.095703,18.134765 3.22825,2.697001 8.618125,7.379782 13.484375,11.894532 4.86625,-4.51475 10.254172,-9.197531 13.482422,-11.894532 6.854788,-5.726744 11.095703,-10.563686 11.095703,-18.134765 0,-13.116556 -16.174681,-19.860331 -24.578125,-4.84961 -3.413899,-6.098105 -8.110694,-8.60616 -12.484375,-8.554687 z"
+   id="path1"
+   style="opacity:1;fill:#404040;fill-opacity:1"
+   sodipodi:nodetypes="csscc" />
 </svg>

--- a/gui/assets/tex/heart_white.svg
+++ b/gui/assets/tex/heart_white.svg
@@ -1,9 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#FFFFFF" d="M35.84,21.358c-11.368-11.92-27-6-27,9c0,14.684,14.842,18.631,21.158,24.947
-	c0.947,0.947,3.711,3.474,5.921,7.895c2.289-4.421,4.974-6.947,5.921-7.895c6-6.316,21-10.264,21-24.632
-	C62.84,15.358,47.051,9.438,35.84,21.358z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="heart_white.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="35.919,15.006906"
+     end_point="35.919,64.825"
+     center_point="35.919,39.915953"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="1.4142136"
+   inkscape:cx="-66.468036"
+   inkscape:cy="154.85638"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#ed2224"
+   d="m 23.435547,17.015625 c -6.392303,0.07523 -12.095703,5.616342 -12.095703,13.404297 0,7.571079 4.240915,12.408022 11.095703,18.134765 3.22825,2.697001 8.618125,7.379782 13.484375,11.894532 4.86625,-4.51475 10.254172,-9.197531 13.482422,-11.894532 6.854788,-5.726744 11.095703,-10.563686 11.095703,-18.134765 0,-13.116556 -16.174681,-19.860331 -24.578125,-4.84961 -3.413899,-6.098105 -8.110694,-8.60616 -12.484375,-8.554687 z"
+   id="path1"
+   style="opacity:1;fill:#ffffff"
+   sodipodi:nodetypes="csscc" />
 </svg>

--- a/gui/assets/tex/spade.svg
+++ b/gui/assets/tex/spade.svg
@@ -1,9 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#010101" d="M36.067,10.646C29.462,25.327,11.332,27.309,9.35,39.199C7.441,51.017,22.636,58.356,33.572,49.988
-	c1.468,3.084-0.367,8.001-3.377,12.111c1.541-0.513,4.624-0.733,5.872-0.733s4.33,0.221,5.872,0.733
-	c-3.01-4.11-4.771-9.027-3.377-12.111c12.772,7.928,26.352,0.882,24.443-10.789C60.95,26.648,42.674,25.327,36.067,10.646z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="spade.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.05,10.65"
+     end_point="36.05,62.099"
+     center_point="36.05,36.3745"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="11.313708"
+   inkscape:cx="52.944621"
+   inkscape:cy="29.698485"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#010101"
+   d="M 36.050781,11.648438 C 27.193094,24.427246 25.656618,25.794969 18.875,32.935547 c -12.0561595,12.21871 3.196813,25.54964 14.132812,17.18164 1.294536,7.940993 -0.757081,8.261624 -4.460937,11.460938 1.534089,-0.510699 6.230538,-0.773039 7.503906,-0.775391 1.273369,0.0024 5.967864,0.264692 7.501953,0.775391 -3.703856,-3.199314 -5.755473,-3.519945 -4.460937,-11.460938 10.936,8.368 26.188972,-4.96293 14.132812,-17.18164 -6.781618,-7.140578 -8.316141,-8.508301 -17.173828,-21.287109 z"
+   id="path1"
+   style="display:inline;opacity:1;fill:#000000"
+   sodipodi:nodetypes="ccccscccc" />
 </svg>

--- a/gui/assets/tex/spade_black.svg
+++ b/gui/assets/tex/spade_black.svg
@@ -1,9 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#404040" d="M36.067,10.646C29.462,25.327,11.332,27.309,9.35,39.199C7.441,51.017,22.636,58.356,33.572,49.988
-	c1.468,3.084-0.367,8.001-3.377,12.111c1.541-0.513,4.624-0.733,5.872-0.733s4.33,0.221,5.872,0.733
-	c-3.01-4.11-4.771-9.027-3.377-12.111c12.772,7.928,26.352,0.882,24.443-10.789C60.95,26.648,42.674,25.327,36.067,10.646z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="spade_black.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.05,10.65"
+     end_point="36.05,62.099"
+     center_point="36.05,36.3745"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="2.8284271"
+   inkscape:cx="55.507883"
+   inkscape:cy="-8.8388348"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#010101"
+   d="M 36.050781,11.648438 C 27.193094,24.427246 25.656618,25.794969 18.875,32.935547 c -12.0561595,12.21871 3.196813,25.54964 14.132812,17.18164 1.294536,7.940993 -0.757081,8.261624 -4.460937,11.460938 1.534089,-0.510699 6.230538,-0.773039 7.503906,-0.775391 1.273369,0.0024 5.967864,0.264692 7.501953,0.775391 -3.703856,-3.199314 -5.755473,-3.519945 -4.460937,-11.460938 10.936,8.368 26.188972,-4.96293 14.132812,-17.18164 -6.781618,-7.140578 -8.316141,-8.508301 -17.173828,-21.287109 z"
+   id="path1"
+   style="display:inline;opacity:1;fill:#404040;fill-opacity:1"
+   sodipodi:nodetypes="ccccscccc" />
 </svg>

--- a/gui/assets/tex/spade_white.svg
+++ b/gui/assets/tex/spade_white.svg
@@ -1,9 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="72px" height="72px" viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
-<path fill="#FFFFFF" d="M36.067,10.646C29.462,25.327,11.332,27.309,9.35,39.199C7.441,51.017,22.636,58.356,33.572,49.988
-	c1.468,3.084-0.367,8.001-3.377,12.111c1.541-0.513,4.624-0.733,5.872-0.733s4.33,0.221,5.872,0.733
-	c-3.01-4.11-4.771-9.027-3.377-12.111c12.772,7.928,26.352,0.882,24.443-10.789C60.95,26.648,42.674,25.327,36.067,10.646z"/>
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="72px"
+   height="72px"
+   viewBox="0 0 72 72"
+   enable-background="new 0 0 72 72"
+   xml:space="preserve"
+   sodipodi:docname="spade_white.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1"><inkscape:path-effect
+     effect="mirror_symmetry"
+     start_point="36.05,10.65"
+     end_point="36.05,62.099"
+     center_point="36.05,36.3745"
+     id="path-effect1"
+     is_visible="true"
+     lpeversion="1.2"
+     lpesatellites=""
+     mode="free"
+     discard_orig_path="false"
+     fuse_paths="true"
+     oposite_fuse="false"
+     split_items="false"
+     split_open="false"
+     link_styles="false" /></defs><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="2.8284271"
+   inkscape:cx="55.507883"
+   inkscape:cy="-8.8388348"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   fill="#010101"
+   d="M 36.050781,11.648438 C 27.193094,24.427246 25.656618,25.794969 18.875,32.935547 c -12.0561595,12.21871 3.196813,25.54964 14.132812,17.18164 1.294536,7.940993 -0.757081,8.261624 -4.460937,11.460938 1.534089,-0.510699 6.230538,-0.773039 7.503906,-0.775391 1.273369,0.0024 5.967864,0.264692 7.501953,0.775391 -3.703856,-3.199314 -5.755473,-3.519945 -4.460937,-11.460938 10.936,8.368 26.188972,-4.96293 14.132812,-17.18164 -6.781618,-7.140578 -8.316141,-8.508301 -17.173828,-21.287109 z"
+   id="path1"
+   style="display:inline;opacity:1;fill:#ffffff"
+   sodipodi:nodetypes="ccccscccc" />
 </svg>

--- a/lib/gamepad/input.c
+++ b/lib/gamepad/input.c
@@ -127,8 +127,8 @@ static inline int32_t s24_le_to_int32(const uint8_t in[3])
 static inline void pack_gyroscope(InputPacketGyroscope *gyro, int32_t yaw, int32_t pitch, int32_t roll)
 {
     int32_to_s24_le(gyro->yaw, yaw);
-    int32_to_s24_le(gyro->pitch, yaw);
-    int32_to_s24_le(gyro->roll, yaw);
+    int32_to_s24_le(gyro->pitch, pitch);
+    int32_to_s24_le(gyro->roll, roll);
 }
 
 static inline uint16_t pack_touchcoord(TouchCoord *unpacked)


### PR DESCRIPTION
the playing card icons used to pair the program to the console didn't really match the same style as the console,
so I took a picture of a gamepad and traced the icons.

this pull requests features only the icon .svg files
<img width="72" height="72" alt="club_black" src="https://github.com/user-attachments/assets/6e5c9c9a-4b53-4817-bd32-21fe1155d9e6" />
<img width="72" height="72" alt="diamond_black" src="https://github.com/user-attachments/assets/70f4006d-a690-46d0-8400-9fdd11be8e86" />
<img width="72" height="72" alt="heart_black" src="https://github.com/user-attachments/assets/fe2a4df2-70a4-415a-b767-0cb8c3add084" />
<img width="72" height="72" alt="spade_black" src="https://github.com/user-attachments/assets/d553e918-2135-41ed-84ac-35d3cb0bd177" />

but I find they look a little bit small in on the buttons.
I'm quite new to coding in C, and don't know of a good way to add an icon scale parameter to vui_button_create, without having to change every existing call of the function, which would probably be extremely annoying and cause merge conflicts.
I saw right now the icon scale is sort of hard-coded to be different, depending on if the button style is "VUI_BUTTON_STYLE_CORNER" or not, maybe a larger icon option could be a separate button style?
but that ternary statement is already quite long as is, i feel like I would just create spaghetti code if I did that

