### PR TITLE
use correct switch guide page for supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ An Arch User Repository (AUR) package called `vanilla-wiiu-git` is available for
 
 ## What devices are supported?
 
+- [Nintendo Switch](https://github.com/vanilla-wiiu/vanilla/wiki/Nintendo-Switch)
 - [Steam Deck](https://github.com/vanilla-wiiu/vanilla/wiki/Steam-Deck)
 - [Linux](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (check [Wi-Fi hardware compatibility](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility))
-- [Nintendo Switch](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (requires [Broadcom firmware patch](https://github.com/vanilla-wiiu/nexmon) or [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#nintendo-switch))
 - [Android](https://github.com/vanilla-wiiu/vanilla/wiki/Android-Setup-Guide) (currently frontend only)
 - [Windows](https://github.com/vanilla-wiiu/vanilla/wiki/Windows-Setup-Guide) (currently frontend only)
 - [Raspberry Pi](https://github.com/vanilla-wiiu/vanilla/wiki/Raspberry-Pi) (requires [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#raspberry-pi))


### PR DESCRIPTION
use actual switch guide page for the switch, and switch it to the top.

i switched the switch guide to the top, as most people who switch to a wii u have a switch imo..
you guys can always switch it back if you don't agree with my switch decision though