### PR TITLE
Update Github Actions to use a newer Node.js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,10 +52,10 @@ jobs:
       if: ${{ matrix.platform.arch != 'x86_64' && matrix.platform.os == 'linux' }}
       run: sudo apt -y update && sudo apt -y install qemu-user-static binfmt-support
 
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@v4
 
     - name: Build Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: docker/${{ matrix.platform.os }}/Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             artifact: vanilla-nintendoswitch-image.zip
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -100,7 +100,7 @@ jobs:
         fi
 
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.platform.os }} ${{ matrix.platform.arch }}
         path: ${{ matrix.platform.artifact }}


### PR DESCRIPTION
This will fix the "Node.js 20 is deprecated" warning you get at the end of your build logs: https://github.com/vanilla-wiiu/vanilla/actions/runs/29878683730/job/88794611937#step:23:2

I had the same problem on a couple of my repos and did the same fix, just bump the actions: https://github.com/ReactorScram/sql-hummus/blob/bc80874e329960bfa151a17251fecdfe5f399420/.github/workflows/build.yml#L16