### PR TITLE
Fix link for Raspberry Pi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An Arch User Repository (AUR) package called `vanilla-wiiu-git` is available for
 - [Linux](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide) (check [Wi-Fi hardware compatibility](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility))
 - [Android](https://github.com/vanilla-wiiu/vanilla/wiki/Android-Setup-Guide) (currently frontend only)
 - [Windows](https://github.com/vanilla-wiiu/vanilla/wiki/Windows-Setup-Guide) (currently frontend only)
-- [Raspberry Pi](https://github.com/vanilla-wiiu/vanilla/wiki/Raspberry-Pi) (requires [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#raspberry-pi))
+- [Raspberry Pi](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#raspberry-pi) (requires [external Wi-Fi adapter](https://github.com/vanilla-wiiu/vanilla/wiki/Linux-Setup-Guide#raspberry-pi))
 - *iOS* - Coming soon
 
 ## What Wi-Fi adapter should I use?


### PR DESCRIPTION
Current readme links to a page that does not exist. As a result, it prompts the user to start creating it.