### PR TITLE
Support the Wii Us wake on wlan implementation to turn on console automatically

### DIFF
--- a/gui/config.c
+++ b/gui/config.c
@@ -66,6 +66,10 @@ void vpi_config_save()
         xmlTextWriterWriteElement(writer, BAD_CAST "bssid", BAD_CAST buf);
         hex_to_string(buf, entry->psk.psk, sizeof(vanilla_psk_t));
         xmlTextWriterWriteElement(writer, BAD_CAST "psk", BAD_CAST buf);
+        if (entry->wifi_frequency) {
+            sprintf(buf, "%u", entry->wifi_frequency);
+            xmlTextWriterWriteElement(writer, BAD_CAST "frequency", BAD_CAST buf);
+        }
         xmlTextWriterEndElement(writer); // console
     }
     xmlTextWriterEndElement(writer); // consoles
@@ -212,14 +216,21 @@ void vpi_config_init()
                         console = child->children;
                         while (console) {
                             if (console->type == XML_ELEMENT_NODE && !strcmp((const char *) console->name, "console")) {
+                                memset(entry, 0, sizeof(*entry));
                                 xmlNodePtr console_info = console->children;
                                 while (console_info) {
+                                    if (console_info->type != XML_ELEMENT_NODE || !console_info->children) {
+                                        console_info = console_info->next;
+                                        continue;
+                                    }
                                     if (!strcmp((const char *) console_info->name, "name")) {
                                         vui_strncpy(entry->name, (const char *) console_info->children->content, sizeof(entry->name));
                                     } else if (!strcmp((const char *) console_info->name, "bssid")) {
                                         string_to_hex(entry->bssid.bssid, sizeof(entry->bssid), (const char *) console_info->children->content);
                                     } else if (!strcmp((const char *) console_info->name, "psk")) {
                                         string_to_hex(entry->psk.psk, sizeof(entry->psk), (const char *) console_info->children->content);
+                                    } else if (!strcmp((const char *) console_info->name, "frequency")) {
+                                        entry->wifi_frequency = (uint32_t) strtoul((const char *) console_info->children->content, 0, 10);
                                     }
                                     console_info = console_info->next;
                                 }

--- a/gui/config.h
+++ b/gui/config.h
@@ -14,6 +14,7 @@ typedef struct {
     char name[VPI_CONSOLE_MAX_NAME];
     vanilla_bssid_t bssid;
     vanilla_psk_t psk;
+    uint32_t wifi_frequency;
 } vpi_console_entry_t;
 
 typedef struct {

--- a/gui/menu/menu_game.c
+++ b/gui/menu/menu_game.c
@@ -10,6 +10,7 @@
 #include <libswscale/swscale.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -1088,7 +1089,14 @@ void vpi_menu_game_start(vui_context_t *vui, void *v)
     vanilla_set_region(vpi_config.region);
 
     vpi_console_entry_t *entry = vpi_config.connected_console_entries + console;
-    int r = vanilla_start(vpi_config.server_address, entry->bssid, entry->psk);
+    vanilla_connection_t connection;
+    memset(&connection, 0, sizeof(connection));
+    connection.bssid = entry->bssid;
+    connection.psk = entry->psk;
+    connection.wifi_frequency = entry->wifi_frequency;
+    connection.region = vpi_config.region;
+
+    int r = vanilla_start_connection(vpi_config.server_address, connection);
     if (r != VANILLA_SUCCESS) {
         show_error(vui, (void*)(intptr_t) r);
     } else {

--- a/gui/menu/menu_sync.c
+++ b/gui/menu/menu_sync.c
@@ -95,14 +95,17 @@ void sync_animation_step(vui_context_t *ctx, int64_t time, void *userdata)
 
             for (uint8_t i = 0; i < vpi_config.connected_console_count; i++) {
                 if (!memcmp(vpi_config.connected_console_entries[i].bssid.bssid, sync->data.bssid.bssid, sizeof(vanilla_bssid_t))) {
-                    // We don't bother checking PSK because BSSID is already unique and the PSK should not have changed
                     found = i;
+                    vpi_config.connected_console_entries[i].psk = sync->data.psk;
+                    vpi_config.connected_console_entries[i].wifi_frequency = sync->data.wifi_frequency;
+                    vpi_config_save();
                     break;
                 }
             }
 
             if (found == -1) {
                 vpi_console_entry_t console;
+                memset(&console, 0, sizeof(console));
                 if (vpi_config.connected_console_count == 0) {
                     // Most users will only have one Wii U, so for their first
                     // sync, just use "Wii U" instead of "Wii U 1"
@@ -112,6 +115,7 @@ void sync_animation_step(vui_context_t *ctx, int64_t time, void *userdata)
                 }
                 console.bssid = sync->data.bssid;
                 console.psk = sync->data.psk;
+                console.wifi_frequency = sync->data.wifi_frequency;
                 found = vpi_config_add_console(&console);
             }
 

--- a/lib/gamepad/command.c
+++ b/lib/gamepad/command.c
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "gamepad.h"
@@ -258,7 +259,7 @@ void handle_command_packet(gamepad_context_t *info, int skt, CmdHeader *request)
         switch (request->query_type)
         {
         default:
-            // vanilla_log("[Command] Unhandled request command: %u", request->query_type);
+            vanilla_log("[Command] Unhandled request command: %u", request->query_type);
             break;
         }
         break;

--- a/lib/gamepad/gamepad.c
+++ b/lib/gamepad/gamepad.c
@@ -253,8 +253,7 @@ void sync_internal(thread_data_t *data)
                 break;
             } else if (recv_cmd.control_code == VANILLA_PIPE_CC_SYNC_SUCCESS) {
                 syncdata.status = VANILLA_SUCCESS;
-                syncdata.data.bssid = recv_cmd.connection.bssid;
-                syncdata.data.psk = recv_cmd.connection.psk;
+                syncdata.data = recv_cmd.connection;
                 break;
             } else if (recv_cmd.control_code == VANILLA_PIPE_CC_PING) {
                 // Pipe is still responsive but hasn't found anything yet
@@ -324,12 +323,13 @@ void connect_as_gamepad_internal(thread_data_t *data)
     vanilla_pipe_command_t cmd;
     cmd.control_code = VANILLA_PIPE_CC_CONNECT;
 
-    cmd.connection.bssid = data->bssid;
-    cmd.connection.psk = data->psk;
+    cmd.connection = data->connection;
 
     // Connect to backend pipe
     ret = connect_to_backend(&pipe_cc_skt, &cmd, sizeof(cmd.control_code) + sizeof(cmd.connection));
     if (ret == VANILLA_SUCCESS) {
+        info.connection = data->connection;
+
         // Wait for backend to be available
         vanilla_pipe_command_t connected_state;
         ret = VANILLA_ERR_NO_CONNECTION;

--- a/lib/gamepad/gamepad.h
+++ b/lib/gamepad/gamepad.h
@@ -41,6 +41,7 @@ typedef struct
     int socket_hid;
     int socket_msg;
     int socket_cmd;
+    vanilla_connection_t connection;
 } gamepad_context_t;
 
 typedef struct thread_data_t thread_data_t;
@@ -51,8 +52,7 @@ typedef struct thread_data_t
     event_loop_t *event_loop;
     thread_start_t thread_start;
     void *thread_data;
-    vanilla_bssid_t bssid;
-    vanilla_psk_t psk;
+    vanilla_connection_t connection;
 } thread_data_t;
 
 typedef union {

--- a/lib/vanilla.c
+++ b/lib/vanilla.c
@@ -82,7 +82,7 @@ exit:
     return 0;
 }
 
-int vanilla_start_internal(uint32_t server_address, vanilla_bssid_t bssid, vanilla_psk_t psk, thread_start_t thread_start, void *thread_data)
+int vanilla_start_internal(uint32_t server_address, vanilla_connection_t connection, thread_start_t thread_start, void *thread_data)
 {
     if (pthread_mutex_trylock(&main_mutex) == 0) {
         pthread_t other;
@@ -91,8 +91,7 @@ int vanilla_start_internal(uint32_t server_address, vanilla_bssid_t bssid, vanil
         data->server_address = server_address;
         data->thread_start = thread_start;
         data->thread_data = thread_data;
-        data->bssid = bssid;
-        data->psk = psk;
+        data->connection = connection;
 
         // Lock event loop mutex so it can't be set to active until we're ready
         pthread_mutex_lock(&event_loop.mutex);
@@ -119,7 +118,17 @@ int vanilla_start_internal(uint32_t server_address, vanilla_bssid_t bssid, vanil
 
 int vanilla_start(uint32_t server_address, vanilla_bssid_t bssid, vanilla_psk_t psk)
 {
-    return vanilla_start_internal(server_address, bssid, psk, connect_as_gamepad_internal, 0);
+    vanilla_connection_t connection;
+    memset(&connection, 0, sizeof(connection));
+    connection.bssid = bssid;
+    connection.psk = psk;
+    connection.region = VANILLA_REGION_AMERICA;
+    return vanilla_start_connection(server_address, connection);
+}
+
+int vanilla_start_connection(uint32_t server_address, vanilla_connection_t connection)
+{
+    return vanilla_start_internal(server_address, connection, connect_as_gamepad_internal, 0);
 }
 
 void vanilla_stop()
@@ -200,7 +209,9 @@ void vanilla_set_battery_status(int battery_status)
 
 int vanilla_sync(uint16_t code, uint32_t server_address)
 {
-    return vanilla_start_internal(server_address, (vanilla_bssid_t){.bssid = {0}}, (vanilla_psk_t){.psk = {0}}, sync_internal, (void *) (uintptr_t) code);
+    vanilla_connection_t connection;
+    memset(&connection, 0, sizeof(connection));
+    return vanilla_start_internal(server_address, connection, sync_internal, (void *) (uintptr_t) code);
 }
 
 int vanilla_install_polkit(uint32_t server_address)

--- a/lib/vanilla.h
+++ b/lib/vanilla.h
@@ -111,6 +111,8 @@ typedef struct { unsigned char psk[32]; } vanilla_psk_t;
 typedef struct {
     vanilla_bssid_t bssid;
     vanilla_psk_t psk;
+    uint32_t wifi_frequency;
+    uint8_t region;
 } vanilla_connection_t;
 typedef struct {
     int status;
@@ -122,6 +124,7 @@ typedef struct {
  * Start listening for gamepad commands
  */
 int vanilla_start(uint32_t server_address, vanilla_bssid_t bssid, vanilla_psk_t psk);
+int vanilla_start_connection(uint32_t server_address, vanilla_connection_t connection);
 int vanilla_sync(uint16_t code, uint32_t server_address);
 
 void vanilla_set_wireless_interface(const char *intf);

--- a/pipe/linux/CMakeLists.txt
+++ b/pipe/linux/CMakeLists.txt
@@ -3,6 +3,7 @@ include(ExternalProject)
 # Add vanilla-pipe executalbe
 add_executable(vanilla-pipe
     main.c
+    wiiu_wowl.c
     wpa.c
 )
 
@@ -22,6 +23,7 @@ if (VANILLA_BUILD_VENDORED)
 	# Build OpenSSL
 	set(OPENSSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl)
 	set(OPENSSL_INSTALL_DIR ${OPENSSL_DIR}/install)
+	set(OPENSSL_INCLUDE_DIR "${OPENSSL_INSTALL_DIR}/include")
 	set(OPENSSL_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR})
 	set(OPENSSL_EXTRA_FLAGS "")
 	if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm")
@@ -234,6 +236,7 @@ target_include_directories(vanilla-pipe PRIVATE
     ${HOSTAP_DIR}/wpa_supplicant
     ${CMAKE_SOURCE_DIR}/lib
     ${LibNL_INCLUDE_DIR}
+    ${OPENSSL_INCLUDE_DIR}
 )
 
 # Link our library with the client library

--- a/pipe/linux/wiiu_wowl.c
+++ b/pipe/linux/wiiu_wowl.c
@@ -4,15 +4,20 @@
 #include <errno.h>
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
+#include <linux/nl80211.h>
 #include <net/if.h>
 #include <net/if_arp.h>
+#include <netlink/attr.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/genl.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
 #include <openssl/evp.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "wpa.h"
@@ -206,78 +211,115 @@ static int set_interface_down(const char *ifname)
     return set_interface_up_state(ifname, 0);
 }
 
-static void log_command_failure(const char * const args[], int status)
+typedef int (*Nl80211AddAttrs)(struct nl_msg *msg, void *data);
+
+static int nl80211_send(
+    const char *ifname,
+    enum nl80211_commands command,
+    const char *description,
+    Nl80211AddAttrs add_attrs,
+    void *data)
 {
-    char command[256] = {0};
-    size_t offset = 0;
-
-    for (int i = 0; args[i]; i++) {
-        int written = snprintf(command + offset, sizeof(command) - offset,
-            "%s%s", i ? " " : "", args[i]);
-        if (written < 0 || (size_t) written >= sizeof(command) - offset) {
-            break;
-        }
-        offset += written;
-    }
-
-    if (WIFEXITED(status)) {
-        nlprint("Wii U WOWL: command failed (%d): %s", WEXITSTATUS(status), command);
-    } else if (WIFSIGNALED(status)) {
-        nlprint("Wii U WOWL: command killed by signal %d: %s", WTERMSIG(status), command);
-    } else {
-        nlprint("Wii U WOWL: command failed: %s", command);
-    }
-}
-
-static int run_command(const char * const args[])
-{
-    pid_t pid = fork();
-    if (pid < 0) {
-        nlprint("Wii U WOWL: failed to fork command: %i", errno);
+    unsigned int ifindex = if_nametoindex(ifname);
+    if (!ifindex) {
+        nlprint("Wii U WOWL: failed to resolve interface index for %s: %i",
+            ifname, errno);
         return -1;
     }
 
-    if (pid == 0) {
-        execvp(args[0], (char * const *) args);
-        _exit(127);
-    }
-
-    int status = 0;
-    if (waitpid(pid, &status, 0) < 0) {
-        nlprint("Wii U WOWL: failed to wait for command: %i", errno);
+    struct nl_sock *skt = nl_socket_alloc();
+    if (!skt) {
+        nlprint("Wii U WOWL: failed to allocate netlink socket");
         return -1;
     }
 
-    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-        log_command_failure(args, status);
+    int ret = genl_connect(skt);
+    if (ret < 0) {
+        nlprint("Wii U WOWL: failed to connect generic netlink socket: %s",
+            nl_geterror(ret));
+        nl_socket_free(skt);
+        return -1;
+    }
+
+    int nl80211_id = genl_ctrl_resolve(skt, "nl80211");
+    if (nl80211_id < 0) {
+        nlprint("Wii U WOWL: failed to resolve nl80211 family: %s",
+            nl_geterror(nl80211_id));
+        nl_socket_free(skt);
+        return -1;
+    }
+
+    struct nl_msg *msg = nlmsg_alloc();
+    if (!msg) {
+        nlprint("Wii U WOWL: failed to allocate nl80211 message");
+        nl_socket_free(skt);
+        return -1;
+    }
+
+    if (!genlmsg_put(msg, 0, 0, nl80211_id, 0, 0, command, 0)
+        || nla_put_u32(msg, NL80211_ATTR_IFINDEX, ifindex) < 0
+        || add_attrs(msg, data) < 0) {
+        nlprint("Wii U WOWL: failed to build nl80211 %s request for %s",
+            description, ifname);
+        nlmsg_free(msg);
+        nl_socket_free(skt);
+        return -1;
+    }
+
+    ret = nl_send_auto_complete(skt, msg);
+    nlmsg_free(msg);
+    if (ret < 0) {
+        nlprint("Wii U WOWL: failed to send nl80211 %s request for %s: %s",
+            description, ifname, nl_geterror(ret));
+        nl_socket_free(skt);
+        return -1;
+    }
+
+    ret = nl_wait_for_ack(skt);
+    nl_socket_free(skt);
+    if (ret < 0) {
+        nlprint("Wii U WOWL: nl80211 %s request failed for %s: %s",
+            description, ifname, nl_geterror(ret));
         return -1;
     }
 
     return 0;
 }
 
-//TODO: replace iw cli calls with libnl
-static int iw_set_type(const char *ifname, const char *type)
+static int nl80211_add_interface_type(struct nl_msg *msg, void *data)
 {
-    const char *args[] = {"iw", "dev", ifname, "set", "type", type, NULL};
-    if (run_command(args) < 0) {
+    const enum nl80211_iftype *iftype = data;
+    return nla_put_u32(msg, NL80211_ATTR_IFTYPE, *iftype);
+}
+
+static int nl80211_add_frequency(struct nl_msg *msg, void *data)
+{
+    const uint32_t *frequency = data;
+    return nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, *frequency);
+}
+
+static int nl80211_set_interface_type(
+    const char *ifname,
+    enum nl80211_iftype iftype,
+    const char *name)
+{
+    if (nl80211_send(ifname, NL80211_CMD_SET_INTERFACE, "set interface type",
+            nl80211_add_interface_type, &iftype) < 0) {
         return -1;
     }
 
-    nlprint("Wii U WOWL: iw set %s type %s", ifname, type);
+    nlprint("Wii U WOWL: nl80211 set %s type %s", ifname, name);
     return 0;
 }
 
-static int iw_set_frequency(const char *ifname, uint32_t frequency)
+static int nl80211_set_frequency(const char *ifname, uint32_t frequency)
 {
-    char frequency_arg[16];
-    snprintf(frequency_arg, sizeof(frequency_arg), "%u", frequency);
-    const char *args[] = {"iw", "dev", ifname, "set", "freq", frequency_arg, NULL};
-    if (run_command(args) < 0) {
+    if (nl80211_send(ifname, NL80211_CMD_SET_WIPHY, "set frequency",
+            nl80211_add_frequency, &frequency) < 0) {
         return -1;
     }
 
-    nlprint("Wii U WOWL: iw tuned %s to %u MHz", ifname, frequency);
+    nlprint("Wii U WOWL: nl80211 tuned %s to %u MHz", ifname, frequency);
     return 0;
 }
 
@@ -660,7 +702,7 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
             nlprint("Wii U WOWL: temporarily brought %s down for channel control", ifname);
         }
 
-        if (iw_set_type(ifname, "monitor") < 0) {
+        if (nl80211_set_interface_type(ifname, NL80211_IFTYPE_MONITOR, "monitor") < 0) {
             if (restore_base_up) {
                 set_interface_up(ifname);
             }
@@ -672,7 +714,7 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
 
         unsigned char type_check_mac[WIIU_WOWL_DA_LEN];
         if (get_interface_info(tx_ifname, type_check_mac, &tx_arphrd) < 0) {
-            iw_set_type(ifname, "station");
+            nl80211_set_interface_type(ifname, NL80211_IFTYPE_STATION, "station");
             if (restore_base_up) {
                 set_interface_up(ifname);
             }
@@ -681,16 +723,16 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
 
         nlprint("Wii U WOWL: temporarily set %s to monitor mode", ifname);
         if (set_interface_up(ifname) < 0) {
-            iw_set_type(ifname, "station");
+            nl80211_set_interface_type(ifname, NL80211_IFTYPE_STATION, "station");
             if (restore_base_up) {
                 set_interface_up(ifname);
             }
             return -1;
         }
 
-        if (iw_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
+        if (nl80211_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
             set_interface_down(ifname);
-            iw_set_type(ifname, "station");
+            nl80211_set_interface_type(ifname, NL80211_IFTYPE_STATION, "station");
             if (restore_base_up) {
                 set_interface_up(ifname);
             }
@@ -709,7 +751,7 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
             return -1;
         }
 
-        if (iw_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
+        if (nl80211_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
             return -1;
         }
     }
@@ -727,7 +769,7 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
 
     if (restore_station_type) {
         set_interface_down(ifname);
-        iw_set_type(ifname, "station");
+        nl80211_set_interface_type(ifname, NL80211_IFTYPE_STATION, "station");
         nlprint("Wii U WOWL: restored %s to station mode", ifname);
     }
     if (restore_base_up) {

--- a/pipe/linux/wiiu_wowl.c
+++ b/pipe/linux/wiiu_wowl.c
@@ -62,7 +62,6 @@
 #define WIIU_WOWL_NET_PATTERN_PLAINTEXT_OFFSET \
     (WIIU_WOWL_NET_PATTERN_OFFSET - WIIU_WOWL_ETH_HEADER_LEN)
 #define WIIU_WOWL_PAIRING_SSID_LENGTH 16
-#define WIIU_WOWL_KEY_SEED 0
 #define WIIU_WOWL_COUNTRY_LEN 2
 
 #ifndef ARPHRD_IEEE80211
@@ -112,8 +111,8 @@ static void region_country_code(uint8_t region, unsigned char country[WIIU_WOWL_
         break;
     case VANILLA_REGION_AMERICA:
     default:
-        country[0] = 'U';
-        country[1] = 'S';
+        country[0] = 'Q';
+        country[1] = '2';
         break;
     }
 }
@@ -121,6 +120,7 @@ static void region_country_code(uint8_t region, unsigned char country[WIIU_WOWL_
 static void derive_sta1_wowl_key(
     unsigned char key[WIIU_WOWL_KEY_LEN],
     uint8_t region,
+    uint8_t seed,
     const unsigned char wake_token[WIIU_WOWL_DA_LEN],
     const unsigned char source_mac[WIIU_WOWL_DA_LEN])
 {
@@ -136,11 +136,16 @@ static void derive_sta1_wowl_key(
     memcpy(raw + 4, wake_token, WIIU_WOWL_DA_LEN);
     memcpy(raw + 10, source_mac, WIIU_WOWL_DA_LEN);
 
-    uint8_t prev = WIIU_WOWL_KEY_SEED;
+    uint8_t prev = seed;
     for (int i = WIIU_WOWL_KEY_LEN - 1; i >= 0; i--) {
         prev ^= raw[i];
         key[i] = prev;
     }
+}
+
+static uint8_t seed_from_psk(const vanilla_psk_t *psk)
+{
+    return psk->psk[sizeof(psk->psk) - 1] & 0x0f;
 }
 
 static int get_interface_info(const char *ifname, unsigned char mac[WIIU_WOWL_DA_LEN], int *arphrd)
@@ -890,9 +895,12 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
     region_country_code(connection->region, country);
 
     unsigned char wowl_key[WIIU_WOWL_KEY_LEN];
-    derive_sta1_wowl_key(wowl_key, connection->region, connection->bssid.bssid, iface_mac);
-    nlprint("Wii U WOWL: using region %u country %c%c for key derivation",
-        connection->region, country[0], country[1]);
+    uint8_t seed = seed_from_psk(&connection->psk);
+    nlprint("Wii U WOWL: My seed is: %x", seed);
+    derive_sta1_wowl_key(wowl_key, connection->region, seed,
+        connection->bssid.bssid, iface_mac);
+    nlprint("Wii U WOWL: using region %u country %c%c seed 0x%x for key derivation",
+        connection->region, country[0], country[1], seed);
 
     int ret = sweep_wake_frequencies(tx_ifname, tx_arphrd, connection->wifi_frequency,
         wowl_key, connection->bssid.bssid, iface_mac);

--- a/pipe/linux/wiiu_wowl.c
+++ b/pipe/linux/wiiu_wowl.c
@@ -63,6 +63,16 @@
     (WIIU_WOWL_NET_PATTERN_OFFSET - WIIU_WOWL_ETH_HEADER_LEN)
 #define WIIU_WOWL_PAIRING_SSID_LENGTH 16
 #define WIIU_WOWL_COUNTRY_LEN 2
+#define WIIU_WOWL_CCMP_AAD_LEN 24
+#define WIIU_WOWL_CCMP_NONCE_LEN 13
+#define WIIU_WOWL_MAC_STR_LEN 18
+#define WIIU_WOWL_FRAME_MAX_LEN \
+    (WIIU_WOWL_RADIOTAP_MAX_LEN \
+        + WIIU_WOWL_80211_QOS_HDR_LEN \
+        + WIIU_WOWL_CCMP_HEADER_LEN \
+        + WIIU_WOWL_PLAINTEXT_LEN \
+        + WIIU_WOWL_CCMP_MIC_LEN)
+#define WIIU_WOWL_ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
 
 #ifndef ARPHRD_IEEE80211
 #define ARPHRD_IEEE80211 801
@@ -89,6 +99,14 @@ static void put_le16(unsigned char *out, uint16_t value)
 {
     out[0] = value & 0xff;
     out[1] = value >> 8;
+}
+
+static void put_le32(unsigned char *out, uint32_t value)
+{
+    out[0] = value & 0xff;
+    out[1] = (value >> 8) & 0xff;
+    out[2] = (value >> 16) & 0xff;
+    out[3] = (value >> 24) & 0xff;
 }
 
 static void format_mac(const unsigned char mac[WIIU_WOWL_DA_LEN], char *out, size_t out_size)
@@ -148,6 +166,12 @@ static uint8_t seed_from_psk(const vanilla_psk_t *psk)
     return psk->psk[sizeof(psk->psk) - 1] & 0x0f;
 }
 
+static void init_ifreq(struct ifreq *ifr, const char *ifname)
+{
+    memset(ifr, 0, sizeof(*ifr));
+    snprintf(ifr->ifr_name, sizeof(ifr->ifr_name), "%s", ifname);
+}
+
 static int get_interface_info(const char *ifname, unsigned char mac[WIIU_WOWL_DA_LEN], int *arphrd)
 {
     int skt = socket(AF_INET, SOCK_DGRAM, 0);
@@ -157,8 +181,7 @@ static int get_interface_info(const char *ifname, unsigned char mac[WIIU_WOWL_DA
     }
 
     struct ifreq ifr;
-    memset(&ifr, 0, sizeof(ifr));
-    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+    init_ifreq(&ifr, ifname);
 
     if (ioctl(skt, SIOCGIFHWADDR, &ifr) < 0) {
         nlprint("Wii U WOWL: failed to read %s hardware address: %i", ifname, errno);
@@ -181,8 +204,7 @@ static int get_interface_flags(const char *ifname, short *flags)
     }
 
     struct ifreq ifr;
-    memset(&ifr, 0, sizeof(ifr));
-    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+    init_ifreq(&ifr, ifname);
 
     if (ioctl(skt, SIOCGIFFLAGS, &ifr) < 0) {
         nlprint("Wii U WOWL: failed to read %s flags: %i", ifname, errno);
@@ -209,8 +231,7 @@ static int set_interface_up_state(const char *ifname, int up)
     }
 
     struct ifreq ifr;
-    memset(&ifr, 0, sizeof(ifr));
-    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+    init_ifreq(&ifr, ifname);
     ifr.ifr_flags = up ? (flags | IFF_UP) : (flags & ~IFF_UP);
 
     if (ioctl(skt, SIOCSIFFLAGS, &ifr) < 0) {
@@ -460,10 +481,7 @@ static size_t build_radiotap_header(
     case WIIU_WOWL_RADIOTAP_LEGACY: {
         uint32_t present = WIIU_WOWL_RADIOTAP_RATE_PRESENT
             | WIIU_WOWL_RADIOTAP_TX_FLAGS_PRESENT;
-        frame[4] = present & 0xff;
-        frame[5] = (present >> 8) & 0xff;
-        frame[6] = (present >> 16) & 0xff;
-        frame[7] = (present >> 24) & 0xff;
+        put_le32(frame + 4, present);
         frame[8] = WIIU_WOWL_RADIOTAP_RATE_6MBPS;
         put_le16(frame + 10, WIIU_WOWL_RADIOTAP_TX_FLAGS_NOACK);
         break;
@@ -471,10 +489,7 @@ static size_t build_radiotap_header(
     case WIIU_WOWL_RADIOTAP_MCS0: {
         uint32_t present = WIIU_WOWL_RADIOTAP_TX_FLAGS_PRESENT
             | WIIU_WOWL_RADIOTAP_MCS_PRESENT;
-        frame[4] = present & 0xff;
-        frame[5] = (present >> 8) & 0xff;
-        frame[6] = (present >> 16) & 0xff;
-        frame[7] = (present >> 24) & 0xff;
+        put_le32(frame + 4, present);
         put_le16(frame + 8, WIIU_WOWL_RADIOTAP_TX_FLAGS_NOACK);
         frame[10] = WIIU_WOWL_RADIOTAP_MCS_KNOWN;
         frame[11] = 0; // 20 MHz, long GI.
@@ -490,7 +505,7 @@ static size_t build_radiotap_header(
 }
 
 static void build_ccmp_aad(
-    unsigned char aad[24],
+    unsigned char aad[WIIU_WOWL_CCMP_AAD_LEN],
     const unsigned char hdr[WIIU_WOWL_80211_QOS_HDR_LEN])
 {
     uint16_t fc = hdr[0] | (hdr[1] << 8);
@@ -511,10 +526,10 @@ static void build_ccmp_aad(
 }
 
 static void build_ccmp_nonce(
-    unsigned char nonce[13],
+    unsigned char nonce[WIIU_WOWL_CCMP_NONCE_LEN],
     const unsigned char src[WIIU_WOWL_DA_LEN])
 {
-    memset(nonce, 0, 13);
+    memset(nonce, 0, WIIU_WOWL_CCMP_NONCE_LEN);
     nonce[0] = WIIU_WOWL_QOS_TID;
     memcpy(nonce + 1, src, WIIU_WOWL_DA_LEN);
     nonce[12] = WIIU_WOWL_CCMP_PN & 0xff;
@@ -522,7 +537,7 @@ static void build_ccmp_nonce(
 
 static int encrypt_ccmp(
     const unsigned char key[WIIU_WOWL_KEY_LEN],
-    const unsigned char nonce[13],
+    const unsigned char nonce[WIIU_WOWL_CCMP_NONCE_LEN],
     const unsigned char *aad,
     size_t aad_len,
     const unsigned char *plaintext,
@@ -543,7 +558,7 @@ static int encrypt_ccmp(
     if (EVP_EncryptInit_ex(ctx, EVP_aes_128_ccm(), NULL, NULL, NULL) != 1) {
         goto exit;
     }
-    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_IVLEN, 13, NULL) != 1) {
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_IVLEN, WIIU_WOWL_CCMP_NONCE_LEN, NULL) != 1) {
         goto exit;
     }
     if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_TAG, WIIU_WOWL_CCMP_MIC_LEN, NULL) != 1) {
@@ -600,8 +615,8 @@ static size_t build_wake_frame(
     }
 
     unsigned char hdr[WIIU_WOWL_80211_QOS_HDR_LEN];
-    unsigned char aad[24];
-    unsigned char nonce[13];
+    unsigned char aad[WIIU_WOWL_CCMP_AAD_LEN];
+    unsigned char nonce[WIIU_WOWL_CCMP_NONCE_LEN];
     unsigned char plaintext[WIIU_WOWL_PLAINTEXT_LEN];
     unsigned char ccmp[WIIU_WOWL_CCMP_HEADER_LEN];
     unsigned char ciphertext[WIIU_WOWL_PLAINTEXT_LEN];
@@ -638,6 +653,62 @@ static size_t build_wake_frame(
     return offset;
 }
 
+static int send_wake_frame(
+    int skt,
+    const struct sockaddr_ll *addr,
+    enum WowlRadiotapMode radiotap_mode,
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN],
+    int frame_index,
+    int *last_errno)
+{
+    unsigned char frame[WIIU_WOWL_FRAME_MAX_LEN];
+    size_t frame_len = build_wake_frame(frame, sizeof(frame), radiotap_mode,
+        key, dst, src, frame_index);
+
+    if (!frame_len) {
+        return -1;
+    }
+
+    ssize_t written = sendto(skt, frame, frame_len, 0,
+        (const struct sockaddr *) addr, sizeof(*addr));
+    if (written != (ssize_t) frame_len) {
+        *last_errno = errno;
+        return 0;
+    }
+
+    return 1;
+}
+
+static int send_wake_burst(
+    int skt,
+    const struct sockaddr_ll *addr,
+    enum WowlRadiotapMode radiotap_mode,
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN],
+    int start_index,
+    int frame_count,
+    int *sent,
+    int *last_errno)
+{
+    for (int i = 0; i < frame_count && !is_interrupted(); i++) {
+        int result = send_wake_frame(skt, addr, radiotap_mode, key, dst, src,
+            start_index + i, last_errno);
+        if (result < 0) {
+            return -1;
+        }
+        if (result > 0) {
+            (*sent)++;
+        }
+
+        usleep(WIIU_WOWL_TX_GAP_US);
+    }
+
+    return 0;
+}
+
 static int inject_wake_frames(
     const char *ifname,
     int arphrd,
@@ -660,8 +731,8 @@ static int inject_wake_frames(
         return -1;
     }
 
-    char dst_str[18];
-    char src_str[18];
+    char dst_str[WIIU_WOWL_MAC_STR_LEN];
+    char src_str[WIIU_WOWL_MAC_STR_LEN];
     format_mac(dst, dst_str, sizeof(dst_str));
     format_mac(src, src_str, sizeof(src_str));
     nlprint("Wii U WOWL: injecting Broadcom net-pattern wake frame on %s: dst=%s src=%s pn=%u mcs0=%u legacy=%u",
@@ -683,56 +754,23 @@ static int inject_wake_frames(
     addr.sll_halen = WIIU_WOWL_DA_LEN;
     memcpy(addr.sll_addr, dst, WIIU_WOWL_DA_LEN);
 
-    unsigned char frame[WIIU_WOWL_RADIOTAP_MAX_LEN
-        + WIIU_WOWL_80211_QOS_HDR_LEN
-        + WIIU_WOWL_CCMP_HEADER_LEN
-        + WIIU_WOWL_PLAINTEXT_LEN
-        + WIIU_WOWL_CCMP_MIC_LEN];
-
     int sent = 0;
     int last_errno = 0;
     if (radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY) {
-        for (int i = 0; i < WIIU_WOWL_TX_MCS0_COUNT && !is_interrupted(); i++) {
-            size_t frame_len = build_wake_frame(frame, sizeof(frame), WIIU_WOWL_RADIOTAP_MCS0,
-                key, dst, src, i);
-
-            if (!frame_len) {
-                close(skt);
-                return -1;
-            }
-
-            ssize_t written = sendto(skt, frame, frame_len, 0,
-                (const struct sockaddr *) &addr, sizeof(addr));
-            if (written == (ssize_t) frame_len) {
-                sent++;
-            } else {
-                last_errno = errno;
-            }
-
-            usleep(WIIU_WOWL_TX_GAP_US);
-        }
-    }
-
-    for (int i = 0; i < WIIU_WOWL_TX_COUNT && !is_interrupted(); i++) {
-        int frame_index = i
-            + (radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY ? WIIU_WOWL_TX_MCS0_COUNT : 0);
-        size_t frame_len = build_wake_frame(frame, sizeof(frame), radiotap_mode,
-            key, dst, src, frame_index);
-
-        if (!frame_len) {
+        if (send_wake_burst(skt, &addr, WIIU_WOWL_RADIOTAP_MCS0, key, dst, src,
+                0, WIIU_WOWL_TX_MCS0_COUNT, &sent, &last_errno) < 0) {
             close(skt);
             return -1;
         }
+    }
 
-        ssize_t written = sendto(skt, frame, frame_len, 0,
-            (const struct sockaddr *) &addr, sizeof(addr));
-        if (written == (ssize_t) frame_len) {
-            sent++;
-        } else {
-            last_errno = errno;
-        }
-
-        usleep(WIIU_WOWL_TX_GAP_US);
+    int start_index = radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY
+        ? WIIU_WOWL_TX_MCS0_COUNT
+        : 0;
+    if (send_wake_burst(skt, &addr, radiotap_mode, key, dst, src,
+            start_index, WIIU_WOWL_TX_COUNT, &sent, &last_errno) < 0) {
+        close(skt);
+        return -1;
     }
 
     close(skt);
@@ -782,8 +820,7 @@ static int sweep_wake_frequencies(
 {
     int sent_any = 0;
     int tried_preferred = 0;
-    size_t frequency_count = sizeof(wiiu_wowl_sweep_frequencies)
-        / sizeof(wiiu_wowl_sweep_frequencies[0]);
+    size_t frequency_count = WIIU_WOWL_ARRAY_SIZE(wiiu_wowl_sweep_frequencies);
 
     if (preferred_frequency) {
         nlprint("Wii U WOWL: sweeping %zu 5GHz wake channels, preferred %u MHz first",
@@ -896,7 +933,6 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
 
     unsigned char wowl_key[WIIU_WOWL_KEY_LEN];
     uint8_t seed = seed_from_psk(&connection->psk);
-    nlprint("Wii U WOWL: My seed is: %x", seed);
     derive_sta1_wowl_key(wowl_key, connection->region, seed,
         connection->bssid.bssid, iface_mac);
     nlprint("Wii U WOWL: using region %u country %c%c seed 0x%x for key derivation",

--- a/pipe/linux/wiiu_wowl.c
+++ b/pipe/linux/wiiu_wowl.c
@@ -28,10 +28,14 @@
 #define WIIU_WOWL_CCMP_HEADER_LEN 8
 #define WIIU_WOWL_CCMP_MIC_LEN 8
 #define WIIU_WOWL_80211_QOS_HDR_LEN 26
-#define WIIU_WOWL_RADIOTAP_LEGACY_LEN 8
-#define WIIU_WOWL_RADIOTAP_MCS_LEN 11
+#define WIIU_WOWL_RADIOTAP_LEGACY_LEN 12
+#define WIIU_WOWL_RADIOTAP_MCS_LEN 13
 #define WIIU_WOWL_RADIOTAP_MAX_LEN WIIU_WOWL_RADIOTAP_MCS_LEN
+#define WIIU_WOWL_RADIOTAP_RATE_PRESENT 0x00000004
+#define WIIU_WOWL_RADIOTAP_TX_FLAGS_PRESENT 0x00008000
 #define WIIU_WOWL_RADIOTAP_MCS_PRESENT 0x00080000
+#define WIIU_WOWL_RADIOTAP_TX_FLAGS_NOACK 0x0008
+#define WIIU_WOWL_RADIOTAP_RATE_6MBPS 12
 #define WIIU_WOWL_RADIOTAP_MCS_HAVE_BW 0x01
 #define WIIU_WOWL_RADIOTAP_MCS_HAVE_MCS 0x02
 #define WIIU_WOWL_RADIOTAP_MCS_HAVE_GI 0x04
@@ -39,9 +43,15 @@
     (WIIU_WOWL_RADIOTAP_MCS_HAVE_BW \
         | WIIU_WOWL_RADIOTAP_MCS_HAVE_MCS \
         | WIIU_WOWL_RADIOTAP_MCS_HAVE_GI)
-#define WIIU_WOWL_TX_COUNT 256
+#define WIIU_WOWL_TX_COUNT 352
 #define WIIU_WOWL_TX_MCS0_COUNT 3
 #define WIIU_WOWL_TX_GAP_US 250
+#define WIIU_WOWL_TX_DRAIN_US 2000
+#define WIIU_WOWL_MONITOR_SETTLE_US 100000
+#define WIIU_WOWL_SET_FREQ_RETRIES 6
+#define WIIU_WOWL_SET_FREQ_PREFERRED_RETRIES 2
+#define WIIU_WOWL_SET_FREQ_RETRY_BASE_US 20000
+#define WIIU_WOWL_SET_FREQ_RETRY_MAX_US 200000
 #define WIIU_WOWL_TX_PER_SEQ 16
 #define WIIU_WOWL_QOS_TID 7
 #define WIIU_WOWL_DURATION 0x003c
@@ -67,6 +77,13 @@ enum WowlRadiotapMode
     WIIU_WOWL_RADIOTAP_NONE,
     WIIU_WOWL_RADIOTAP_LEGACY,
     WIIU_WOWL_RADIOTAP_MCS0
+};
+
+static const uint32_t wiiu_wowl_sweep_frequencies[] = {
+    5180, 5200, 5220, 5240, 5260, 5280, 5300, 5320,
+    5500, 5520, 5540, 5560, 5580, 5600, 5620, 5640,
+    5660, 5680, 5700, 5720, 5745, 5765, 5785, 5805,
+    5825
 };
 
 static void put_le16(unsigned char *out, uint16_t value)
@@ -220,11 +237,15 @@ static int nl80211_send(
     Nl80211AddAttrs add_attrs,
     void *data)
 {
-    unsigned int ifindex = if_nametoindex(ifname);
-    if (!ifindex) {
-        nlprint("Wii U WOWL: failed to resolve interface index for %s: %i",
-            ifname, errno);
-        return -1;
+    const char *target = ifname ? ifname : "global";
+    unsigned int ifindex = 0;
+    if (ifname) {
+        ifindex = if_nametoindex(ifname);
+        if (!ifindex) {
+            nlprint("Wii U WOWL: failed to resolve interface index for %s: %i",
+                ifname, errno);
+            return -1;
+        }
     }
 
     struct nl_sock *skt = nl_socket_alloc();
@@ -257,10 +278,10 @@ static int nl80211_send(
     }
 
     if (!genlmsg_put(msg, 0, 0, nl80211_id, 0, 0, command, 0)
-        || nla_put_u32(msg, NL80211_ATTR_IFINDEX, ifindex) < 0
+        || (ifname && nla_put_u32(msg, NL80211_ATTR_IFINDEX, ifindex) < 0)
         || add_attrs(msg, data) < 0) {
         nlprint("Wii U WOWL: failed to build nl80211 %s request for %s",
-            description, ifname);
+            description, target);
         nlmsg_free(msg);
         nl_socket_free(skt);
         return -1;
@@ -270,20 +291,26 @@ static int nl80211_send(
     nlmsg_free(msg);
     if (ret < 0) {
         nlprint("Wii U WOWL: failed to send nl80211 %s request for %s: %s",
-            description, ifname, nl_geterror(ret));
+            description, target, nl_geterror(ret));
         nl_socket_free(skt);
-        return -1;
+        return ret;
     }
 
     ret = nl_wait_for_ack(skt);
     nl_socket_free(skt);
     if (ret < 0) {
         nlprint("Wii U WOWL: nl80211 %s request failed for %s: %s",
-            description, ifname, nl_geterror(ret));
-        return -1;
+            description, target, nl_geterror(ret));
+        return ret;
     }
 
     return 0;
+}
+
+static int nl80211_error_is_busy(int ret)
+{
+    const char *error = ret < 0 ? nl_geterror(ret) : NULL;
+    return ret == -EBUSY || (error && !strcmp(error, "Object busy"));
 }
 
 static int nl80211_add_interface_type(struct nl_msg *msg, void *data)
@@ -296,6 +323,12 @@ static int nl80211_add_frequency(struct nl_msg *msg, void *data)
 {
     const uint32_t *frequency = data;
     return nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, *frequency);
+}
+
+static int nl80211_add_reg_alpha2(struct nl_msg *msg, void *data)
+{
+    const char *alpha2 = data;
+    return nla_put(msg, NL80211_ATTR_REG_ALPHA2, 2, alpha2);
 }
 
 static int nl80211_set_interface_type(
@@ -312,15 +345,42 @@ static int nl80211_set_interface_type(
     return 0;
 }
 
-static int nl80211_set_frequency(const char *ifname, uint32_t frequency)
+static int nl80211_set_frequency_retry(
+    const char *ifname,
+    uint32_t frequency,
+    int retries)
 {
-    if (nl80211_send(ifname, NL80211_CMD_SET_WIPHY, "set frequency",
-            nl80211_add_frequency, &frequency) < 0) {
-        return -1;
+    int ret = 0;
+
+    for (int attempt = 0; attempt <= retries; attempt++) {
+        ret = nl80211_send(ifname, NL80211_CMD_SET_WIPHY, "set frequency",
+            nl80211_add_frequency, &frequency);
+        if (ret == 0) {
+            nlprint("Wii U WOWL: nl80211 tuned %s to %u MHz", ifname, frequency);
+            return 0;
+        }
+
+        if (!nl80211_error_is_busy(ret) || attempt == retries
+            || is_interrupted()) {
+            break;
+        }
+
+        unsigned int delay = WIIU_WOWL_SET_FREQ_RETRY_BASE_US << attempt;
+        if (delay > WIIU_WOWL_SET_FREQ_RETRY_MAX_US) {
+            delay = WIIU_WOWL_SET_FREQ_RETRY_MAX_US;
+        }
+
+        nlprint("Wii U WOWL: %s busy while tuning to %u MHz, retrying in %u us (%d/%d)",
+            ifname, frequency, delay, attempt + 1, retries);
+        usleep(delay);
     }
 
-    nlprint("Wii U WOWL: nl80211 tuned %s to %u MHz", ifname, frequency);
-    return 0;
+    if (nl80211_error_is_busy(ret)) {
+        nlprint("Wii U WOWL: failed to tune %s to %u MHz after busy retries",
+            ifname, frequency);
+    }
+
+    return -1;
 }
 
 static void build_wowl_plaintext(
@@ -391,14 +451,34 @@ static size_t build_radiotap_header(
     memset(frame, 0, radiotap_len);
     put_le16(frame + 2, (uint16_t) radiotap_len);
 
-    if (mode == WIIU_WOWL_RADIOTAP_MCS0) {
-        frame[4] = WIIU_WOWL_RADIOTAP_MCS_PRESENT & 0xff;
-        frame[5] = (WIIU_WOWL_RADIOTAP_MCS_PRESENT >> 8) & 0xff;
-        frame[6] = (WIIU_WOWL_RADIOTAP_MCS_PRESENT >> 16) & 0xff;
-        frame[7] = (WIIU_WOWL_RADIOTAP_MCS_PRESENT >> 24) & 0xff;
-        frame[8] = WIIU_WOWL_RADIOTAP_MCS_KNOWN;
-        frame[9] = 0;  // 20 MHz, long GI.
-        frame[10] = 0; // MCS index 0.
+    switch (mode) {
+    case WIIU_WOWL_RADIOTAP_LEGACY: {
+        uint32_t present = WIIU_WOWL_RADIOTAP_RATE_PRESENT
+            | WIIU_WOWL_RADIOTAP_TX_FLAGS_PRESENT;
+        frame[4] = present & 0xff;
+        frame[5] = (present >> 8) & 0xff;
+        frame[6] = (present >> 16) & 0xff;
+        frame[7] = (present >> 24) & 0xff;
+        frame[8] = WIIU_WOWL_RADIOTAP_RATE_6MBPS;
+        put_le16(frame + 10, WIIU_WOWL_RADIOTAP_TX_FLAGS_NOACK);
+        break;
+    }
+    case WIIU_WOWL_RADIOTAP_MCS0: {
+        uint32_t present = WIIU_WOWL_RADIOTAP_TX_FLAGS_PRESENT
+            | WIIU_WOWL_RADIOTAP_MCS_PRESENT;
+        frame[4] = present & 0xff;
+        frame[5] = (present >> 8) & 0xff;
+        frame[6] = (present >> 16) & 0xff;
+        frame[7] = (present >> 24) & 0xff;
+        put_le16(frame + 8, WIIU_WOWL_RADIOTAP_TX_FLAGS_NOACK);
+        frame[10] = WIIU_WOWL_RADIOTAP_MCS_KNOWN;
+        frame[11] = 0; // 20 MHz, long GI.
+        frame[12] = 0; // MCS index 0.
+        break;
+    }
+    case WIIU_WOWL_RADIOTAP_NONE:
+    default:
+        break;
     }
 
     return radiotap_len;
@@ -669,15 +749,76 @@ static int inject_wake_frames(
     return 0;
 }
 
+static int tune_and_inject_wake(
+    const char *ifname,
+    int arphrd,
+    uint32_t frequency,
+    int frequency_retries,
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN])
+{
+    if (nl80211_set_frequency_retry(ifname, frequency, frequency_retries) < 0) {
+        return -1;
+    }
+
+    int ret = inject_wake_frames(ifname, arphrd, key, dst, src);
+    usleep(WIIU_WOWL_TX_DRAIN_US);
+    return ret;
+}
+
+static int sweep_wake_frequencies(
+    const char *ifname,
+    int arphrd,
+    uint32_t preferred_frequency,
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN])
+{
+    int sent_any = 0;
+    int tried_preferred = 0;
+    size_t frequency_count = sizeof(wiiu_wowl_sweep_frequencies)
+        / sizeof(wiiu_wowl_sweep_frequencies[0]);
+
+    if (preferred_frequency) {
+        nlprint("Wii U WOWL: sweeping %zu 5GHz wake channels, preferred %u MHz first",
+            frequency_count, preferred_frequency);
+    } else {
+        nlprint("Wii U WOWL: sweeping %zu 5GHz wake channels", frequency_count);
+    }
+
+    if (preferred_frequency) {
+        tried_preferred = 1;
+        if (tune_and_inject_wake(ifname, arphrd, preferred_frequency,
+                WIIU_WOWL_SET_FREQ_PREFERRED_RETRIES, key, dst, src) == 0) {
+            sent_any = 1;
+        }
+    }
+
+    for (size_t i = 0; i < frequency_count && !is_interrupted(); i++) {
+        uint32_t frequency = wiiu_wowl_sweep_frequencies[i];
+        if (tried_preferred && frequency == preferred_frequency) {
+            continue;
+        }
+
+        if (tune_and_inject_wake(ifname, arphrd, frequency,
+                WIIU_WOWL_SET_FREQ_RETRIES, key, dst, src) == 0) {
+            sent_any = 1;
+        }
+    }
+
+    if (!sent_any) {
+        nlprint("Wii U WOWL: failed to inject wake frames on any swept channel");
+        return -1;
+    }
+
+    return 0;
+}
+
 int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connection)
 {
     if (!ifname || !connection) {
         nlprint("Wii U WOWL: missing interface or connection");
-        return -1;
-    }
-
-    if (!connection->wifi_frequency) {
-        nlprint("Wii U WOWL: no stored Wi-Fi frequency, skipping wake packet");
         return -1;
     }
 
@@ -729,15 +870,7 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
             }
             return -1;
         }
-
-        if (nl80211_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
-            set_interface_down(ifname);
-            nl80211_set_interface_type(ifname, NL80211_IFTYPE_STATION, "station");
-            if (restore_base_up) {
-                set_interface_up(ifname);
-            }
-            return -1;
-        }
+        usleep(WIIU_WOWL_MONITOR_SETTLE_US);
     } else {
         short tx_flags = 0;
         if (get_interface_flags(tx_ifname, &tx_flags) == 0 && (tx_flags & IFF_UP)) {
@@ -750,10 +883,7 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
         if (set_interface_up(tx_ifname) < 0) {
             return -1;
         }
-
-        if (nl80211_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
-            return -1;
-        }
+        usleep(WIIU_WOWL_MONITOR_SETTLE_US);
     }
 
     unsigned char country[WIIU_WOWL_COUNTRY_LEN];
@@ -764,8 +894,8 @@ int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connectio
     nlprint("Wii U WOWL: using region %u country %c%c for key derivation",
         connection->region, country[0], country[1]);
 
-    int ret = inject_wake_frames(tx_ifname, tx_arphrd, wowl_key,
-        connection->bssid.bssid, iface_mac);
+    int ret = sweep_wake_frequencies(tx_ifname, tx_arphrd, connection->wifi_frequency,
+        wowl_key, connection->bssid.bssid, iface_mac);
 
     if (restore_station_type) {
         set_interface_down(ifname);

--- a/pipe/linux/wiiu_wowl.c
+++ b/pipe/linux/wiiu_wowl.c
@@ -1,0 +1,739 @@
+#include "wiiu_wowl.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <openssl/evp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "wpa.h"
+
+#define WIIU_WOWL_DA_LEN 6
+#define WIIU_WOWL_KEY_LEN 16
+#define WIIU_WOWL_PLAINTEXT_LEN 25
+#define WIIU_WOWL_CCMP_HEADER_LEN 8
+#define WIIU_WOWL_CCMP_MIC_LEN 8
+#define WIIU_WOWL_80211_QOS_HDR_LEN 26
+#define WIIU_WOWL_RADIOTAP_LEGACY_LEN 8
+#define WIIU_WOWL_RADIOTAP_MCS_LEN 11
+#define WIIU_WOWL_RADIOTAP_MAX_LEN WIIU_WOWL_RADIOTAP_MCS_LEN
+#define WIIU_WOWL_RADIOTAP_MCS_PRESENT 0x00080000
+#define WIIU_WOWL_RADIOTAP_MCS_HAVE_BW 0x01
+#define WIIU_WOWL_RADIOTAP_MCS_HAVE_MCS 0x02
+#define WIIU_WOWL_RADIOTAP_MCS_HAVE_GI 0x04
+#define WIIU_WOWL_RADIOTAP_MCS_KNOWN \
+    (WIIU_WOWL_RADIOTAP_MCS_HAVE_BW \
+        | WIIU_WOWL_RADIOTAP_MCS_HAVE_MCS \
+        | WIIU_WOWL_RADIOTAP_MCS_HAVE_GI)
+#define WIIU_WOWL_TX_COUNT 256
+#define WIIU_WOWL_TX_MCS0_COUNT 3
+#define WIIU_WOWL_TX_GAP_US 250
+#define WIIU_WOWL_TX_PER_SEQ 16
+#define WIIU_WOWL_QOS_TID 7
+#define WIIU_WOWL_DURATION 0x003c
+#define WIIU_WOWL_SEQ_START 0x02c0
+#define WIIU_WOWL_CCMP_PN 1
+#define WIIU_WOWL_ETH_HEADER_LEN 14
+#define WIIU_WOWL_NET_PATTERN_OFFSET 15
+#define WIIU_WOWL_NET_PATTERN_PLAINTEXT_OFFSET \
+    (WIIU_WOWL_NET_PATTERN_OFFSET - WIIU_WOWL_ETH_HEADER_LEN)
+#define WIIU_WOWL_PAIRING_SSID_LENGTH 16
+#define WIIU_WOWL_KEY_SEED 0
+#define WIIU_WOWL_COUNTRY_LEN 2
+
+#ifndef ARPHRD_IEEE80211
+#define ARPHRD_IEEE80211 801
+#endif
+#ifndef ARPHRD_IEEE80211_RADIOTAP
+#define ARPHRD_IEEE80211_RADIOTAP 803
+#endif
+
+enum WowlRadiotapMode
+{
+    WIIU_WOWL_RADIOTAP_NONE,
+    WIIU_WOWL_RADIOTAP_LEGACY,
+    WIIU_WOWL_RADIOTAP_MCS0
+};
+
+static void put_le16(unsigned char *out, uint16_t value)
+{
+    out[0] = value & 0xff;
+    out[1] = value >> 8;
+}
+
+static void format_mac(const unsigned char mac[WIIU_WOWL_DA_LEN], char *out, size_t out_size)
+{
+    snprintf(out, out_size, "%02x:%02x:%02x:%02x:%02x:%02x",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+static void region_country_code(uint8_t region, unsigned char country[WIIU_WOWL_COUNTRY_LEN])
+{
+    switch (region) {
+    case VANILLA_REGION_JAPAN:
+        country[0] = 'J';
+        country[1] = 'P';
+        break;
+    case VANILLA_REGION_EUROPE:
+    case VANILLA_REGION_AUSTRALIA:
+        country[0] = 'E';
+        country[1] = 'U';
+        break;
+    case VANILLA_REGION_AMERICA:
+    default:
+        country[0] = 'U';
+        country[1] = 'S';
+        break;
+    }
+}
+
+static void derive_sta1_wowl_key(
+    unsigned char key[WIIU_WOWL_KEY_LEN],
+    uint8_t region,
+    const unsigned char wake_token[WIIU_WOWL_DA_LEN],
+    const unsigned char source_mac[WIIU_WOWL_DA_LEN])
+{
+    unsigned char country[WIIU_WOWL_COUNTRY_LEN];
+    region_country_code(region, country);
+
+    unsigned char raw[WIIU_WOWL_KEY_LEN];
+    memset(raw, 0, sizeof(raw));
+    raw[0] = WIIU_WOWL_PAIRING_SSID_LENGTH;
+    raw[1] = country[0];
+    raw[2] = country[1];
+    raw[3] = WIIU_WOWL_COUNTRY_LEN;
+    memcpy(raw + 4, wake_token, WIIU_WOWL_DA_LEN);
+    memcpy(raw + 10, source_mac, WIIU_WOWL_DA_LEN);
+
+    uint8_t prev = WIIU_WOWL_KEY_SEED;
+    for (int i = WIIU_WOWL_KEY_LEN - 1; i >= 0; i--) {
+        prev ^= raw[i];
+        key[i] = prev;
+    }
+}
+
+static int get_interface_info(const char *ifname, unsigned char mac[WIIU_WOWL_DA_LEN], int *arphrd)
+{
+    int skt = socket(AF_INET, SOCK_DGRAM, 0);
+    if (skt < 0) {
+        nlprint("Wii U WOWL: failed to open ioctl socket: %i", errno);
+        return -1;
+    }
+
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+
+    if (ioctl(skt, SIOCGIFHWADDR, &ifr) < 0) {
+        nlprint("Wii U WOWL: failed to read %s hardware address: %i", ifname, errno);
+        close(skt);
+        return -1;
+    }
+
+    memcpy(mac, ifr.ifr_hwaddr.sa_data, WIIU_WOWL_DA_LEN);
+    *arphrd = ifr.ifr_hwaddr.sa_family;
+    close(skt);
+    return 0;
+}
+
+static int get_interface_flags(const char *ifname, short *flags)
+{
+    int skt = socket(AF_INET, SOCK_DGRAM, 0);
+    if (skt < 0) {
+        nlprint("Wii U WOWL: failed to open ioctl socket: %i", errno);
+        return -1;
+    }
+
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+
+    if (ioctl(skt, SIOCGIFFLAGS, &ifr) < 0) {
+        nlprint("Wii U WOWL: failed to read %s flags: %i", ifname, errno);
+        close(skt);
+        return -1;
+    }
+
+    *flags = ifr.ifr_flags;
+    close(skt);
+    return 0;
+}
+
+static int set_interface_up_state(const char *ifname, int up)
+{
+    short flags = 0;
+    if (get_interface_flags(ifname, &flags) < 0) {
+        return -1;
+    }
+
+    int skt = socket(AF_INET, SOCK_DGRAM, 0);
+    if (skt < 0) {
+        nlprint("Wii U WOWL: failed to open ioctl socket: %i", errno);
+        return -1;
+    }
+
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+    ifr.ifr_flags = up ? (flags | IFF_UP) : (flags & ~IFF_UP);
+
+    if (ioctl(skt, SIOCSIFFLAGS, &ifr) < 0) {
+        nlprint("Wii U WOWL: failed to bring %s %s: %i", ifname, up ? "up" : "down", errno);
+        close(skt);
+        return -1;
+    }
+
+    close(skt);
+    return 0;
+}
+
+static int set_interface_up(const char *ifname)
+{
+    return set_interface_up_state(ifname, 1);
+}
+
+static int set_interface_down(const char *ifname)
+{
+    return set_interface_up_state(ifname, 0);
+}
+
+static void log_command_failure(const char * const args[], int status)
+{
+    char command[256] = {0};
+    size_t offset = 0;
+
+    for (int i = 0; args[i]; i++) {
+        int written = snprintf(command + offset, sizeof(command) - offset,
+            "%s%s", i ? " " : "", args[i]);
+        if (written < 0 || (size_t) written >= sizeof(command) - offset) {
+            break;
+        }
+        offset += written;
+    }
+
+    if (WIFEXITED(status)) {
+        nlprint("Wii U WOWL: command failed (%d): %s", WEXITSTATUS(status), command);
+    } else if (WIFSIGNALED(status)) {
+        nlprint("Wii U WOWL: command killed by signal %d: %s", WTERMSIG(status), command);
+    } else {
+        nlprint("Wii U WOWL: command failed: %s", command);
+    }
+}
+
+static int run_command(const char * const args[])
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        nlprint("Wii U WOWL: failed to fork command: %i", errno);
+        return -1;
+    }
+
+    if (pid == 0) {
+        execvp(args[0], (char * const *) args);
+        _exit(127);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        nlprint("Wii U WOWL: failed to wait for command: %i", errno);
+        return -1;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        log_command_failure(args, status);
+        return -1;
+    }
+
+    return 0;
+}
+
+//TODO: replace iw cli calls with libnl
+static int iw_set_type(const char *ifname, const char *type)
+{
+    const char *args[] = {"iw", "dev", ifname, "set", "type", type, NULL};
+    if (run_command(args) < 0) {
+        return -1;
+    }
+
+    nlprint("Wii U WOWL: iw set %s type %s", ifname, type);
+    return 0;
+}
+
+static int iw_set_frequency(const char *ifname, uint32_t frequency)
+{
+    char frequency_arg[16];
+    snprintf(frequency_arg, sizeof(frequency_arg), "%u", frequency);
+    const char *args[] = {"iw", "dev", ifname, "set", "freq", frequency_arg, NULL};
+    if (run_command(args) < 0) {
+        return -1;
+    }
+
+    nlprint("Wii U WOWL: iw tuned %s to %u MHz", ifname, frequency);
+    return 0;
+}
+
+static void build_wowl_plaintext(
+    unsigned char plaintext[WIIU_WOWL_PLAINTEXT_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN])
+{
+    memset(plaintext, 0, WIIU_WOWL_PLAINTEXT_LEN);
+    memcpy(plaintext + WIIU_WOWL_NET_PATTERN_PLAINTEXT_OFFSET,
+        dst, WIIU_WOWL_DA_LEN);
+}
+
+static void build_qos_data_header(
+    unsigned char hdr[WIIU_WOWL_80211_QOS_HDR_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN],
+    uint16_t seq_control,
+    int retry)
+{
+    uint16_t fc = 0x4188; // QoS Data, ToDS, Protected.
+    if (retry) {
+        fc |= 0x0800;
+    }
+
+    memset(hdr, 0, WIIU_WOWL_80211_QOS_HDR_LEN);
+    put_le16(hdr + 0, fc);
+    put_le16(hdr + 2, WIIU_WOWL_DURATION);
+    memcpy(hdr + 4, dst, WIIU_WOWL_DA_LEN);   // RA/BSSID
+    memcpy(hdr + 10, src, WIIU_WOWL_DA_LEN);  // TA/SA
+    memcpy(hdr + 16, dst, WIIU_WOWL_DA_LEN);  // DA
+    put_le16(hdr + 22, seq_control);
+    put_le16(hdr + 24, WIIU_WOWL_QOS_TID);
+}
+
+static void build_ccmp_header(unsigned char ccmp[WIIU_WOWL_CCMP_HEADER_LEN])
+{
+    memset(ccmp, 0, WIIU_WOWL_CCMP_HEADER_LEN);
+    ccmp[0] = WIIU_WOWL_CCMP_PN & 0xff;
+    ccmp[1] = (WIIU_WOWL_CCMP_PN >> 8) & 0xff;
+    ccmp[3] = 0x20; // ExtIV set, key index 0.
+}
+
+static size_t radiotap_len_for_mode(enum WowlRadiotapMode mode)
+{
+    switch (mode) {
+    case WIIU_WOWL_RADIOTAP_LEGACY:
+        return WIIU_WOWL_RADIOTAP_LEGACY_LEN;
+    case WIIU_WOWL_RADIOTAP_MCS0:
+        return WIIU_WOWL_RADIOTAP_MCS_LEN;
+    case WIIU_WOWL_RADIOTAP_NONE:
+    default:
+        return 0;
+    }
+}
+
+static size_t build_radiotap_header(
+    unsigned char *frame,
+    size_t frame_size,
+    enum WowlRadiotapMode mode)
+{
+    size_t radiotap_len = radiotap_len_for_mode(mode);
+    if (!radiotap_len) {
+        return 0;
+    }
+    if (frame_size < radiotap_len) {
+        return 0;
+    }
+
+    memset(frame, 0, radiotap_len);
+    put_le16(frame + 2, (uint16_t) radiotap_len);
+
+    if (mode == WIIU_WOWL_RADIOTAP_MCS0) {
+        frame[4] = WIIU_WOWL_RADIOTAP_MCS_PRESENT & 0xff;
+        frame[5] = (WIIU_WOWL_RADIOTAP_MCS_PRESENT >> 8) & 0xff;
+        frame[6] = (WIIU_WOWL_RADIOTAP_MCS_PRESENT >> 16) & 0xff;
+        frame[7] = (WIIU_WOWL_RADIOTAP_MCS_PRESENT >> 24) & 0xff;
+        frame[8] = WIIU_WOWL_RADIOTAP_MCS_KNOWN;
+        frame[9] = 0;  // 20 MHz, long GI.
+        frame[10] = 0; // MCS index 0.
+    }
+
+    return radiotap_len;
+}
+
+static void build_ccmp_aad(
+    unsigned char aad[24],
+    const unsigned char hdr[WIIU_WOWL_80211_QOS_HDR_LEN])
+{
+    uint16_t fc = hdr[0] | (hdr[1] << 8);
+    uint16_t seq = hdr[22] | (hdr[23] << 8);
+    uint16_t qos = hdr[24] | (hdr[25] << 8);
+
+    fc &= (uint16_t) ~(0x0800 | 0x1000 | 0x2000);
+    fc &= (uint16_t) ~0x0070;
+    fc |= 0x4000;
+    fc &= (uint16_t) ~0x8000;
+    seq &= 0x000f;
+    qos &= 0x000f;
+
+    put_le16(aad + 0, fc);
+    memcpy(aad + 2, hdr + 4, 18);
+    put_le16(aad + 20, seq);
+    put_le16(aad + 22, qos);
+}
+
+static void build_ccmp_nonce(
+    unsigned char nonce[13],
+    const unsigned char src[WIIU_WOWL_DA_LEN])
+{
+    memset(nonce, 0, 13);
+    nonce[0] = WIIU_WOWL_QOS_TID;
+    memcpy(nonce + 1, src, WIIU_WOWL_DA_LEN);
+    nonce[12] = WIIU_WOWL_CCMP_PN & 0xff;
+}
+
+static int encrypt_ccmp(
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char nonce[13],
+    const unsigned char *aad,
+    size_t aad_len,
+    const unsigned char *plaintext,
+    size_t plaintext_len,
+    unsigned char *ciphertext,
+    unsigned char mic[WIIU_WOWL_CCMP_MIC_LEN])
+{
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) {
+        nlprint("Wii U WOWL: failed to allocate OpenSSL cipher context");
+        return -1;
+    }
+
+    int ok = 0;
+    int out_len = 0;
+    int tmp_len = 0;
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_128_ccm(), NULL, NULL, NULL) != 1) {
+        goto exit;
+    }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_IVLEN, 13, NULL) != 1) {
+        goto exit;
+    }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_TAG, WIIU_WOWL_CCMP_MIC_LEN, NULL) != 1) {
+        goto exit;
+    }
+    if (EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) != 1) {
+        goto exit;
+    }
+    if (EVP_EncryptUpdate(ctx, NULL, &out_len, NULL, (int) plaintext_len) != 1) {
+        goto exit;
+    }
+    if (EVP_EncryptUpdate(ctx, NULL, &out_len, aad, (int) aad_len) != 1) {
+        goto exit;
+    }
+    if (EVP_EncryptUpdate(ctx, ciphertext, &out_len, plaintext, (int) plaintext_len) != 1) {
+        goto exit;
+    }
+    if (EVP_EncryptFinal_ex(ctx, ciphertext + out_len, &tmp_len) != 1) {
+        goto exit;
+    }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_GET_TAG, WIIU_WOWL_CCMP_MIC_LEN, mic) != 1) {
+        goto exit;
+    }
+
+    ok = 1;
+
+exit:
+    EVP_CIPHER_CTX_free(ctx);
+    if (!ok) {
+        nlprint("Wii U WOWL: failed to encrypt CCMP wake payload");
+        return -1;
+    }
+    return 0;
+}
+
+static size_t build_wake_frame(
+    unsigned char *frame,
+    size_t frame_size,
+    enum WowlRadiotapMode radiotap_mode,
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN],
+    int frame_index)
+{
+    const size_t radiotap_len = radiotap_len_for_mode(radiotap_mode);
+    const size_t frame_len = radiotap_len
+        + WIIU_WOWL_80211_QOS_HDR_LEN
+        + WIIU_WOWL_CCMP_HEADER_LEN
+        + WIIU_WOWL_PLAINTEXT_LEN
+        + WIIU_WOWL_CCMP_MIC_LEN;
+
+    if (frame_size < frame_len) {
+        return 0;
+    }
+
+    unsigned char hdr[WIIU_WOWL_80211_QOS_HDR_LEN];
+    unsigned char aad[24];
+    unsigned char nonce[13];
+    unsigned char plaintext[WIIU_WOWL_PLAINTEXT_LEN];
+    unsigned char ccmp[WIIU_WOWL_CCMP_HEADER_LEN];
+    unsigned char ciphertext[WIIU_WOWL_PLAINTEXT_LEN];
+    unsigned char mic[WIIU_WOWL_CCMP_MIC_LEN];
+    uint16_t seq_control = WIIU_WOWL_SEQ_START
+        + (uint16_t) ((frame_index / WIIU_WOWL_TX_PER_SEQ) << 4);
+    int retry = (frame_index % WIIU_WOWL_TX_PER_SEQ) != 0;
+
+    build_qos_data_header(hdr, dst, src, seq_control, retry);
+    build_ccmp_aad(aad, hdr);
+    build_ccmp_nonce(nonce, src);
+    build_wowl_plaintext(plaintext, dst);
+    build_ccmp_header(ccmp);
+
+    if (encrypt_ccmp(key, nonce, aad, sizeof(aad),
+            plaintext, sizeof(plaintext), ciphertext, mic) < 0) {
+        return 0;
+    }
+
+    size_t offset = 0;
+    if (radiotap_len) {
+        offset += build_radiotap_header(frame, frame_size, radiotap_mode);
+    }
+
+    memcpy(frame + offset, hdr, sizeof(hdr));
+    offset += sizeof(hdr);
+    memcpy(frame + offset, ccmp, sizeof(ccmp));
+    offset += sizeof(ccmp);
+    memcpy(frame + offset, ciphertext, sizeof(ciphertext));
+    offset += sizeof(ciphertext);
+    memcpy(frame + offset, mic, sizeof(mic));
+    offset += sizeof(mic);
+
+    return offset;
+}
+
+static int inject_wake_frames(
+    const char *ifname,
+    int arphrd,
+    const unsigned char key[WIIU_WOWL_KEY_LEN],
+    const unsigned char dst[WIIU_WOWL_DA_LEN],
+    const unsigned char src[WIIU_WOWL_DA_LEN])
+{
+    enum WowlRadiotapMode radiotap_mode = WIIU_WOWL_RADIOTAP_NONE;
+    if (arphrd == ARPHRD_IEEE80211_RADIOTAP) {
+        radiotap_mode = WIIU_WOWL_RADIOTAP_LEGACY;
+    } else if (arphrd != ARPHRD_IEEE80211) {
+        nlprint("Wii U WOWL: %s is not a monitor/raw 802.11 interface (ARPHRD=%d); skipping wake packet",
+            ifname, arphrd);
+        return -1;
+    }
+
+    unsigned int ifindex = if_nametoindex(ifname);
+    if (!ifindex) {
+        nlprint("Wii U WOWL: failed to resolve interface index for %s: %i", ifname, errno);
+        return -1;
+    }
+
+    char dst_str[18];
+    char src_str[18];
+    format_mac(dst, dst_str, sizeof(dst_str));
+    format_mac(src, src_str, sizeof(src_str));
+    nlprint("Wii U WOWL: injecting Broadcom net-pattern wake frame on %s: dst=%s src=%s pn=%u mcs0=%u legacy=%u",
+        ifname, dst_str, src_str, WIIU_WOWL_CCMP_PN,
+        radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY ? WIIU_WOWL_TX_MCS0_COUNT : 0,
+        WIIU_WOWL_TX_COUNT);
+
+    int skt = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (skt < 0) {
+        nlprint("Wii U WOWL: failed to open packet socket: %i", errno);
+        return -1;
+    }
+
+    struct sockaddr_ll addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sll_family = AF_PACKET;
+    addr.sll_protocol = htons(ETH_P_ALL);
+    addr.sll_ifindex = (int) ifindex;
+    addr.sll_halen = WIIU_WOWL_DA_LEN;
+    memcpy(addr.sll_addr, dst, WIIU_WOWL_DA_LEN);
+
+    unsigned char frame[WIIU_WOWL_RADIOTAP_MAX_LEN
+        + WIIU_WOWL_80211_QOS_HDR_LEN
+        + WIIU_WOWL_CCMP_HEADER_LEN
+        + WIIU_WOWL_PLAINTEXT_LEN
+        + WIIU_WOWL_CCMP_MIC_LEN];
+
+    int sent = 0;
+    int last_errno = 0;
+    if (radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY) {
+        for (int i = 0; i < WIIU_WOWL_TX_MCS0_COUNT && !is_interrupted(); i++) {
+            size_t frame_len = build_wake_frame(frame, sizeof(frame), WIIU_WOWL_RADIOTAP_MCS0,
+                key, dst, src, i);
+
+            if (!frame_len) {
+                close(skt);
+                return -1;
+            }
+
+            ssize_t written = sendto(skt, frame, frame_len, 0,
+                (const struct sockaddr *) &addr, sizeof(addr));
+            if (written == (ssize_t) frame_len) {
+                sent++;
+            } else {
+                last_errno = errno;
+            }
+
+            usleep(WIIU_WOWL_TX_GAP_US);
+        }
+    }
+
+    for (int i = 0; i < WIIU_WOWL_TX_COUNT && !is_interrupted(); i++) {
+        int frame_index = i
+            + (radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY ? WIIU_WOWL_TX_MCS0_COUNT : 0);
+        size_t frame_len = build_wake_frame(frame, sizeof(frame), radiotap_mode,
+            key, dst, src, frame_index);
+
+        if (!frame_len) {
+            close(skt);
+            return -1;
+        }
+
+        ssize_t written = sendto(skt, frame, frame_len, 0,
+            (const struct sockaddr *) &addr, sizeof(addr));
+        if (written == (ssize_t) frame_len) {
+            sent++;
+        } else {
+            last_errno = errno;
+        }
+
+        usleep(WIIU_WOWL_TX_GAP_US);
+    }
+
+    close(skt);
+
+    if (!sent) {
+        nlprint("Wii U WOWL: failed to inject wake frames: %i", last_errno);
+        return -1;
+    }
+
+    unsigned int expected = WIIU_WOWL_TX_COUNT
+        + (radiotap_mode == WIIU_WOWL_RADIOTAP_LEGACY ? WIIU_WOWL_TX_MCS0_COUNT : 0);
+    if (sent != (int) expected) {
+        nlprint("Wii U WOWL: injected %d/%u wake frames, last error: %i",
+            sent, expected, last_errno);
+    } else {
+        nlprint("Wii U WOWL: injected %d wake frames", sent);
+    }
+
+    return 0;
+}
+
+int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connection)
+{
+    if (!ifname || !connection) {
+        nlprint("Wii U WOWL: missing interface or connection");
+        return -1;
+    }
+
+    if (!connection->wifi_frequency) {
+        nlprint("Wii U WOWL: no stored Wi-Fi frequency, skipping wake packet");
+        return -1;
+    }
+
+    unsigned char iface_mac[WIIU_WOWL_DA_LEN];
+    int arphrd = 0;
+    if (get_interface_info(ifname, iface_mac, &arphrd) < 0) {
+        return -1;
+    }
+
+    const char *tx_ifname = ifname;
+    int tx_arphrd = arphrd;
+    int restore_station_type = 0;
+    int restore_base_up = 0;
+
+    if (arphrd == ARPHRD_ETHER) {
+        short base_flags = 0;
+        if (get_interface_flags(ifname, &base_flags) == 0 && (base_flags & IFF_UP)) {
+            if (set_interface_down(ifname) < 0) {
+                return -1;
+            }
+            restore_base_up = 1;
+            nlprint("Wii U WOWL: temporarily brought %s down for channel control", ifname);
+        }
+
+        if (iw_set_type(ifname, "monitor") < 0) {
+            if (restore_base_up) {
+                set_interface_up(ifname);
+            }
+            return -1;
+        }
+
+        restore_station_type = 1;
+        tx_arphrd = ARPHRD_IEEE80211_RADIOTAP;
+
+        unsigned char type_check_mac[WIIU_WOWL_DA_LEN];
+        if (get_interface_info(tx_ifname, type_check_mac, &tx_arphrd) < 0) {
+            iw_set_type(ifname, "station");
+            if (restore_base_up) {
+                set_interface_up(ifname);
+            }
+            return -1;
+        }
+
+        nlprint("Wii U WOWL: temporarily set %s to monitor mode", ifname);
+        if (set_interface_up(ifname) < 0) {
+            iw_set_type(ifname, "station");
+            if (restore_base_up) {
+                set_interface_up(ifname);
+            }
+            return -1;
+        }
+
+        if (iw_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
+            set_interface_down(ifname);
+            iw_set_type(ifname, "station");
+            if (restore_base_up) {
+                set_interface_up(ifname);
+            }
+            return -1;
+        }
+    } else {
+        short tx_flags = 0;
+        if (get_interface_flags(tx_ifname, &tx_flags) == 0 && (tx_flags & IFF_UP)) {
+            if (set_interface_down(tx_ifname) < 0) {
+                return -1;
+            }
+            nlprint("Wii U WOWL: temporarily brought %s down for channel control", tx_ifname);
+        }
+
+        if (set_interface_up(tx_ifname) < 0) {
+            return -1;
+        }
+
+        if (iw_set_frequency(tx_ifname, connection->wifi_frequency) < 0) {
+            return -1;
+        }
+    }
+
+    unsigned char country[WIIU_WOWL_COUNTRY_LEN];
+    region_country_code(connection->region, country);
+
+    unsigned char wowl_key[WIIU_WOWL_KEY_LEN];
+    derive_sta1_wowl_key(wowl_key, connection->region, connection->bssid.bssid, iface_mac);
+    nlprint("Wii U WOWL: using region %u country %c%c for key derivation",
+        connection->region, country[0], country[1]);
+
+    int ret = inject_wake_frames(tx_ifname, tx_arphrd, wowl_key,
+        connection->bssid.bssid, iface_mac);
+
+    if (restore_station_type) {
+        set_interface_down(ifname);
+        iw_set_type(ifname, "station");
+        nlprint("Wii U WOWL: restored %s to station mode", ifname);
+    }
+    if (restore_base_up) {
+        set_interface_up(ifname);
+        nlprint("Wii U WOWL: restored %s after wake injection", ifname);
+    }
+
+    return ret;
+}

--- a/pipe/linux/wiiu_wowl.h
+++ b/pipe/linux/wiiu_wowl.h
@@ -1,0 +1,8 @@
+#ifndef VANILLA_PIPE_LINUX_WIIU_WOWL_H
+#define VANILLA_PIPE_LINUX_WIIU_WOWL_H
+
+#include "vanilla.h"
+
+int wiiu_wowl_try_wake(const char *ifname, const vanilla_connection_t *connection);
+
+#endif // VANILLA_PIPE_LINUX_WIIU_WOWL_H

--- a/pipe/linux/wpa.c
+++ b/pipe/linux/wpa.c
@@ -26,6 +26,7 @@
 #include "dhcp/dhcpc.h"
 #include "util.h"
 #include "vanilla.h"
+#include "wiiu_wowl.h"
 #include "wpa.h"
 
 #ifdef USE_LIBNM
@@ -64,6 +65,8 @@ struct sync_args {
     uint16_t code;
     unsigned char bssid[6];
     unsigned char psk[32];
+    uint32_t wifi_frequency;
+    uint8_t region;
     void *(*start_routine)(void *);
     struct wpa_ctrl *ctrl;
     int local;
@@ -780,6 +783,16 @@ void bytes_to_str(unsigned char *data, size_t data_size, const char *separator, 
     }
 }
 
+static uint32_t parse_scan_result_frequency(const char *line)
+{
+    char bssid[18];
+    unsigned int frequency = 0;
+    if (sscanf(line, "%17s %u", bssid, &frequency) != 2) {
+        return 0;
+    }
+    return frequency;
+}
+
 int create_connect_config(const char *filename, unsigned char *bssid, unsigned char *psk)
 {
     FILE *out_file = fopen(filename, "w");
@@ -883,6 +896,7 @@ void *sync_with_console_internal(void *data)
                 // Make copy of bssid for later
                 strncpy(bssid, line, sizeof(bssid));
                 bssid[17] = '\0';
+                uint32_t scan_frequency = parse_scan_result_frequency(line);
 
                 char wps_buf[100];
                 snprintf(wps_buf, sizeof(wps_buf), "WPS_PIN %.*s %04d5678", 17, bssid, args->code);
@@ -956,6 +970,7 @@ void *sync_with_console_internal(void *data)
 
                         // Convert BSSID from string to bytes
                         str_to_bytes(bssid, 1, cmd.connection.bssid.bssid, sizeof(cmd.connection.bssid.bssid));
+                        cmd.connection.wifi_frequency = scan_frequency;
 
                         sendto(args->skt, &cmd, sizeof(cmd.control_code) + sizeof(cmd.connection), 0, (const struct sockaddr *) &args->client, args->client_size);
 
@@ -1061,6 +1076,13 @@ void *vanilla_connect_to_console(void *data)
     args->wireless_config = get_wireless_connect_config_filename();
 
     create_connect_config(args->wireless_config, args->bssid, args->psk);
+
+    vanilla_connection_t connection = {0};
+    memcpy(connection.bssid.bssid, args->bssid, sizeof(connection.bssid.bssid));
+    memcpy(connection.psk.psk, args->psk, sizeof(connection.psk.psk));
+    connection.wifi_frequency = args->wifi_frequency;
+    connection.region = args->region;
+    wiiu_wowl_try_wake(args->wireless_interface, &connection);
 
     return wpa_setup_environment(args);
 }
@@ -1226,6 +1248,8 @@ void pipe_listen(int local, const char *wireless_interface, const char *log_file
                 } else {
                     memcpy(args->bssid, cmd.connection.bssid.bssid, sizeof(cmd.connection.bssid.bssid));
                     memcpy(args->psk, cmd.connection.psk.psk, sizeof(cmd.connection.psk.psk));
+                    args->wifi_frequency = cmd.connection.wifi_frequency;
+                    args->region = cmd.connection.region;
                     args->start_routine = vanilla_connect_to_console;
                 }
 

--- a/pipe/linux/wpa.h
+++ b/pipe/linux/wpa.h
@@ -9,6 +9,7 @@ struct wpa_ctrl;
 
 void wpa_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd, char *buf, size_t *buf_len);
 int start_wpa_supplicant(const char *wireless_interface, const char *config_file, pid_t *pid);
+int is_interrupted(void);
 
 int is_networkmanager_managing_device(const char *wireless_interface, int *is_managed);
 int disable_networkmanager_on_device(const char *wireless_interface);


### PR DESCRIPTION
Closes #68 

After a lot of reverse engineering the gamepads firmware and it's wifi chips firmware I figured out that the gamepad uses a custom wake on wlan implementation made by broadcom. The gamepad sends a raw 802.11n packet encrypted with a custom key(that is derived based on the console region, paired psk, source/target mac address) to the last connected Wifi channel. If this fails it starts sweeping channels until it succeeds in turning on the console. 

This requires a wifi card that supports monitor mode to perform raw packet injection(as far as I am aware there is no other way to universally do raw packet injection from linux userland)

Me and @itsmattkc tested this quite extensively over a few days, and the only remaining issue is that we aren't 100% sure how the region mapping of the wowl packet works.

<img width="457" height="364" alt="image" src="https://github.com/user-attachments/assets/7c846071-d99a-4d33-884f-1f66f30fdb8b" />

While my EU gamepad does actually use the EU country code his seems to use Q2. 

For technical understanding of how the Wii U performs wowl the two main relevant functions are build_wowl_plaintext (which builds the actual payload included inside the wifi packet and derive_sta1_wowl_key which derives the key used to encrypt the packet. Everything else is pretty much wifi packet building boilerplate and monitor mode setup. The Wii U uses this in both directions, so both to turn on the gamepad via the wii u or the wii u via the gamepad.

If anybody knows of a better way to inject a raw packet in that format or has an idea about the region codes, your comment would be greatly appreciated.