### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/gui/res/com.mattkc.vanilla.desktop
+++ b/gui/res/com.mattkc.vanilla.desktop
@@ -7,3 +7,4 @@ Icon=com.mattkc.vanilla_rounded
 Terminal=false
 Type=Application
 Categories=Game
+StartupWMClass=vanilla


### PR DESCRIPTION
Due to the application name (vanilla) not matching the desktop file name (com.mattkc.vanilla), Linux desktop environments could have trouble matching the desktop file to the application. This causes a running instance of Vanilla to have a separate entry in taskbars/launchers etc.

This patch adds StartupWMClass=vanilla to the .desktop file, which fixes the issue.

<img width="352" height="267" alt="Screenshot From 2026-08-15 16-09-33" src="https://github.com/user-attachments/assets/6b2f00b9-5e47-4105-801a-39a4d881897e" />