### PR TITLE
Fixed Vanilla freezing on reconnect with CUDA

### DIFF
--- a/gui/ui/ui_sdl.c
+++ b/gui/ui/ui_sdl.c
@@ -2087,6 +2087,10 @@ int vui_update_sdl(vui_context_t *vui)
         if (cuda_ctx) {
             if (cuda_ctx->resY) cudaGraphicsUnregisterResource(cuda_ctx->resY);
             if (cuda_ctx->resUV) cudaGraphicsUnregisterResource(cuda_ctx->resUV);
+            if (sdl_ctx->game_tex) {
+                SDL_DestroyTexture(sdl_ctx->game_tex);
+                sdl_ctx->game_tex = NULL;
+            }
             free(cuda_ctx);
             cuda_ctx = NULL;
         }


### PR DESCRIPTION
Frees the game_tex texture when the cuda context is freed, so that it gets recreated and reregistered when a new cuda context is initialized. Fixes Vanilla being stuck on the last frame from the previous session after reconnecting